### PR TITLE
[sample] Add 07_compute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ cmake --build build --config Release
 
 * **[00_hello](src/samples/00_hello)**: Display a surface and clear its color (_Device, Swapchain, dynamic rendering_).
 * **[01_triangle](src/samples/01_triangle)**: Display a simple triangle (_Shader, Graphics Pipeline, Vertex Buffer, Commands_).
-* **[02_push_constant](src/samples/02_push_constant)**: Update per-frame values via push constants and dynamic states.
-* **[03_descriptor_set](src/samples/03_descriptor_set)**: Initialize & update a descriptor set on a single uniform buffer.
-* **[04_texturing](src/samples/04_texturing)**: Display a textured cube with a linear sampler.
-* **[05_stencil_op](src/samples/05_stencil_op)**: Demonstrate instancing and stencil operations through a multi-passes portal effect.
-* **[06_blend_op](src/samples/06_blend_op)**: Display fast & simple GPU particles with additive blend operation.
+* **[02_push_constant](src/samples/02_push_constant)**: Update per-frame values via push constants and dynamic states (_Push Constant_).
+* **[03_descriptor_set](src/samples/03_descriptor_set)**: Initialize & update a descriptor set on a single uniform buffer (_Descriptor Set_).
+* **[04_texturing](src/samples/04_texturing)**: Display a textured cube with a linear sampler (_Image, Sampler_).
+* **[05_stencil_op](src/samples/05_stencil_op)**: Demonstrate instancing and stencil operations through a multi-passes portal effect (_Stencil, instancing_).
+* **[06_blend_op](src/samples/06_blend_op)**: Fast & simple billboarded GPU particles with additive blend operation (_Blending_).
+* **[07_compute](src/samples/07_compute)**: Waves simulation with sorted alpha-blended particles via compute shaders (_Compute Pipeline, Barrier_).
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cmake --build build --config Release
 * **[02_push_constant](src/samples/02_push_constant)**: Update per-frame values via push constants and dynamic states (_Push Constant_).
 * **[03_descriptor_set](src/samples/03_descriptor_set)**: Initialize & update a descriptor set on a single uniform buffer (_Descriptor Set_).
 * **[04_texturing](src/samples/04_texturing)**: Display a textured cube with a linear sampler (_Image, Sampler_).
-* **[05_stencil_op](src/samples/05_stencil_op)**: Demonstrate instancing and stencil operations through a multi-passes portal effect (_Stencil, instancing_).
+* **[05_stencil_op](src/samples/05_stencil_op)**: Stencil operations and instancing through a multi-passes portal effect (_Stencil, instancing_).
 * **[06_blend_op](src/samples/06_blend_op)**: Fast & simple billboarded GPU particles with additive blend operation (_Blending_).
 * **[07_compute](src/samples/07_compute)**: Waves simulation with sorted alpha-blended particles via compute shaders (_Compute Pipeline, Barrier_).
 

--- a/src/framework/backend/allocator.cc
+++ b/src/framework/backend/allocator.cc
@@ -84,7 +84,9 @@ Buffer_t ResourceAllocator::create_buffer(
 
 // ----------------------------------------------------------------------------
 
-Buffer_t ResourceAllocator::create_staging_buffer(size_t const bytesize, void const* host_data) {
+Buffer_t ResourceAllocator::create_staging_buffer(size_t const bytesize, void const* host_data, size_t host_data_size) {
+  assert(host_data_size <= bytesize);
+
   // TODO : use a pool to reuse some staging buffer.
 
   // Create buffer.
@@ -96,7 +98,7 @@ Buffer_t ResourceAllocator::create_staging_buffer(size_t const bytesize, void co
   )};
   // Map host data to device.
   if (host_data != nullptr) {
-    upload_host_to_device(host_data, bytesize, staging_buffer);
+    upload_host_to_device(host_data, (host_data_size > 0u) ? host_data_size : bytesize, staging_buffer);
   }
   staging_buffers_.push_back(staging_buffer);
   return staging_buffer;

--- a/src/framework/backend/allocator.h
+++ b/src/framework/backend/allocator.h
@@ -29,7 +29,7 @@ class ResourceAllocator {
                          VmaMemoryUsage const memory_usage = VMA_MEMORY_USAGE_AUTO,
                          VmaAllocationCreateFlags const flags = {}) const;
 
-  Buffer_t create_staging_buffer(size_t const bytesize = kDefaultStagingBufferSize, void const* host_data = nullptr);
+  Buffer_t create_staging_buffer(size_t const bytesize = kDefaultStagingBufferSize, void const* host_data = nullptr, size_t host_data_size = 0);
 
   template<typename T>
   Buffer_t create_staging_buffer(std::span<T> const& host_data) {

--- a/src/framework/backend/command_encoder.cc
+++ b/src/framework/backend/command_encoder.cc
@@ -43,12 +43,13 @@ void CommandEncoder::copy_buffer(Buffer_t const& src, size_t src_offset, Buffer_
 
 // ----------------------------------------------------------------------------
 
-Buffer_t CommandEncoder::create_buffer_and_upload(void const* host_data, size_t const host_data_size, VkBufferUsageFlags2KHR const usage, size_t const device_buffer_size) const {
+Buffer_t CommandEncoder::create_buffer_and_upload(void const* host_data, size_t const host_data_size, VkBufferUsageFlags2KHR const usage, size_t device_buffer_offet, size_t const device_buffer_size) const {
   assert(host_data != nullptr);
   assert(host_data_size > 0u);
 
   size_t const buffer_bytesize = (device_buffer_size > 0) ? device_buffer_size : host_data_size;
   assert(host_data_size <= buffer_bytesize);
+  // assert(device_buffer_offet + host_data_size < buffer_bytesize);
 
   // [TODO] Staging buffers need cleaning / garbage collection !
   auto staging_buffer{
@@ -61,7 +62,7 @@ Buffer_t CommandEncoder::create_buffer_and_upload(void const* host_data, size_t 
     VMA_MEMORY_USAGE_GPU_ONLY
   )};
 
-  copy_buffer(staging_buffer, 0u, buffer, 0u, host_data_size);
+  copy_buffer(staging_buffer, 0u, buffer, device_buffer_offet, host_data_size);
 
   return buffer;
 }

--- a/src/framework/backend/command_encoder.cc
+++ b/src/framework/backend/command_encoder.cc
@@ -43,21 +43,25 @@ void CommandEncoder::copy_buffer(Buffer_t const& src, size_t src_offset, Buffer_
 
 // ----------------------------------------------------------------------------
 
-Buffer_t CommandEncoder::create_buffer_and_upload(void const* host_data, size_t const size, VkBufferUsageFlags2KHR const usage) const {
+Buffer_t CommandEncoder::create_buffer_and_upload(void const* host_data, size_t const host_data_size, VkBufferUsageFlags2KHR const usage, size_t const device_buffer_size) const {
   assert(host_data != nullptr);
-  assert(size > 0);
+  assert(host_data_size > 0u);
 
+  size_t const buffer_bytesize = (device_buffer_size > 0) ? device_buffer_size : host_data_size;
+  assert(host_data_size <= buffer_bytesize);
+
+  // [TODO] Staging buffers need cleaning / garbage collection !
   auto staging_buffer{
-    allocator_->create_staging_buffer(size, host_data)   /// (need cleaning)
+    allocator_->create_staging_buffer(buffer_bytesize, host_data, host_data_size)   //
   };
 
   auto buffer{allocator_->create_buffer(
-    static_cast<VkDeviceSize>(size),
+    static_cast<VkDeviceSize>(buffer_bytesize),
     usage | VK_BUFFER_USAGE_2_TRANSFER_DST_BIT_KHR,
     VMA_MEMORY_USAGE_GPU_ONLY
   )};
 
-  copy_buffer(staging_buffer, 0u, buffer, 0u, size);
+  copy_buffer(staging_buffer, 0u, buffer, 0u, host_data_size);
 
   return buffer;
 }

--- a/src/framework/backend/command_encoder.h
+++ b/src/framework/backend/command_encoder.h
@@ -41,6 +41,23 @@ class GenericCommandEncoder {
     vkCmdBindDescriptorSets2KHR(command_buffer_, &bind_desc_sets_info);
   }
 
+  // --- Pipeline Barrier ---
+
+  void pipeline_buffer_barriers(std::vector<VkBufferMemoryBarrier2> buffers) const {
+    for (auto& bb : buffers) {
+      bb.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2;
+      bb.srcQueueFamilyIndex = (bb.srcQueueFamilyIndex == 0u) ? VK_QUEUE_FAMILY_IGNORED : bb.srcQueueFamilyIndex;
+      bb.dstQueueFamilyIndex = (bb.dstQueueFamilyIndex == 0u) ? VK_QUEUE_FAMILY_IGNORED : bb.dstQueueFamilyIndex;
+      bb.size = (bb.size == 0ULL) ? VK_WHOLE_SIZE : bb.size;
+    }
+    VkDependencyInfo const dependency{
+      .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
+      .bufferMemoryBarrierCount = static_cast<uint32_t>(buffers.size()),
+      .pBufferMemoryBarriers = buffers.data(),
+    };
+    vkCmdPipelineBarrier2(command_buffer_, &dependency);
+  }
+
  protected:
   VkCommandBuffer command_buffer_{};
 };

--- a/src/framework/backend/command_encoder.h
+++ b/src/framework/backend/command_encoder.h
@@ -72,19 +72,18 @@ class CommandEncoder : public GenericCommandEncoder {
     copy_buffer(src, 0, dst, 0, size);
   }
 
-  Buffer_t create_buffer_and_upload(void const* host_data, size_t const size, VkBufferUsageFlags2KHR const usage) const;
+  Buffer_t create_buffer_and_upload(void const* host_data, size_t const host_data_size, VkBufferUsageFlags2KHR const usage, size_t const device_buffer_size = 0u) const;
 
   template<typename T> requires (SpanConvertible<T>)
-  Buffer_t create_buffer_and_upload(T const& host_data, VkBufferUsageFlags2KHR const usage = {}) const {
+  Buffer_t create_buffer_and_upload(T const& host_data, VkBufferUsageFlags2KHR const usage = {}, size_t const device_buffer_size = 0u) const {
     auto const host_span{ std::span(host_data) };
     size_t const bytesize{ sizeof(typename decltype(host_span)::element_type) * host_span.size() };
-    return create_buffer_and_upload(host_span.data(), bytesize, usage);
+    return create_buffer_and_upload(host_span.data(), bytesize, usage, device_buffer_size);
   }
 
   // --- Images ---
 
   void transition_images_layout(std::vector<Image_t> const& images, VkImageLayout const src_layout, VkImageLayout const dst_layout) const;
-
 
   void copy_buffer_to_image(Buffer_t const& src, Image_t const& dst, VkExtent3D extent, VkImageLayout image_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) const {
     VkBufferImageCopy const copy{

--- a/src/framework/backend/command_encoder.h
+++ b/src/framework/backend/command_encoder.h
@@ -72,13 +72,13 @@ class CommandEncoder : public GenericCommandEncoder {
     copy_buffer(src, 0, dst, 0, size);
   }
 
-  Buffer_t create_buffer_and_upload(void const* host_data, size_t const host_data_size, VkBufferUsageFlags2KHR const usage, size_t const device_buffer_size = 0u) const;
+  Buffer_t create_buffer_and_upload(void const* host_data, size_t const host_data_size, VkBufferUsageFlags2KHR const usage, size_t device_buffer_offet = 0u, size_t const device_buffer_size = 0u) const;
 
   template<typename T> requires (SpanConvertible<T>)
-  Buffer_t create_buffer_and_upload(T const& host_data, VkBufferUsageFlags2KHR const usage = {}, size_t const device_buffer_size = 0u) const {
+  Buffer_t create_buffer_and_upload(T const& host_data, VkBufferUsageFlags2KHR const usage = {}, size_t device_buffer_offet = 0u, size_t const device_buffer_size = 0u) const {
     auto const host_span{ std::span(host_data) };
     size_t const bytesize{ sizeof(typename decltype(host_span)::element_type) * host_span.size() };
-    return create_buffer_and_upload(host_span.data(), bytesize, usage, device_buffer_size);
+    return create_buffer_and_upload(host_span.data(), bytesize, usage, device_buffer_offet, device_buffer_size);
   }
 
   // --- Images ---

--- a/src/framework/backend/types.h
+++ b/src/framework/backend/types.h
@@ -97,14 +97,13 @@ struct ShaderModule_t {
 // ----------------------------------------------------------------------------
 
 struct DescriptorSetLayoutParams_t {
-  std::vector<VkDescriptorSetLayoutBinding> entries;
-  std::vector<VkDescriptorBindingFlags> flags;
+  uint32_t                 binding;
+  VkDescriptorType         descriptorType;
+  uint32_t                 descriptorCount;
+  VkShaderStageFlags       stageFlags;
+  const VkSampler*         pImmutableSamplers;
+  VkDescriptorBindingFlags bindingFlags;
 };
-
-// struct DescriptorSetLayout_t {
-//   DescriptorSetLayoutParams_t params;
-//   VkDescriptorSetLayout layout;
-// };
 
 struct DescriptorSetWriteEntry_t {
   // (use an union instead ?)

--- a/src/framework/backend/types.h
+++ b/src/framework/backend/types.h
@@ -126,24 +126,30 @@ class PipelineInterface {
  public:
   PipelineInterface() = default;
 
-  PipelineInterface(VkPipelineLayout layout, VkPipeline pipeline)
+  PipelineInterface(VkPipelineLayout layout, VkPipeline pipeline, VkPipelineBindPoint bind_point)
     : pipeline_layout_(layout)
     , pipeline_(pipeline)
+    , bind_point_(bind_point)
   {}
 
   virtual ~PipelineInterface() {}
 
-  inline VkPipelineLayout get_layout() const {
+  VkPipelineLayout get_layout() const {
     return pipeline_layout_;
   }
 
-  inline VkPipeline get_handle() const {
+  VkPipeline get_handle() const {
     return pipeline_;
+  }
+
+  VkPipelineBindPoint get_bind_point() const {
+    return bind_point_;
   }
 
  protected:
   VkPipelineLayout pipeline_layout_{};
   VkPipeline pipeline_{};
+  VkPipelineBindPoint bind_point_{};
 };
 
 // ----------------------------------------------------------------------------

--- a/src/framework/backend/vk_utils.h
+++ b/src/framework/backend/vk_utils.h
@@ -26,6 +26,10 @@ VkShaderModule CreateShaderModule(VkDevice const device, char const* shader_dire
 
 std::tuple<VkPipelineStageFlags2, VkAccessFlags2> MakePipelineStageAccessTuple(VkImageLayout const state);
 
+constexpr uint32_t GetKernelGridDim(uint32_t numCells, uint32_t blockDim) {
+  return (numCells + blockDim - 1u) / blockDim;
+}
+
 // ----------------------------------------------------------------------------
 
 template <typename T, typename N>

--- a/src/framework/common.h
+++ b/src/framework/common.h
@@ -13,13 +13,14 @@
 
 #include <algorithm>
 #include <array>
-#include <memory>
-#include <string_view>
-#include <span>
-#include <vector>
 #include <concepts>
-#include <type_traits>
+#include <iostream> //
 #include <iterator> // For std::back_inserter
+#include <memory>
+#include <span>
+#include <string_view>
+#include <type_traits>
+#include <vector>
 
 // linear algebra.
 #include "lina/lina.h"

--- a/src/framework/renderer/pipeline.h
+++ b/src/framework/renderer/pipeline.h
@@ -14,8 +14,8 @@ class Pipeline : public PipelineInterface {
   Pipeline() = default;
   ~Pipeline() = default;
 
-  Pipeline(VkPipelineLayout layout, VkPipeline pipeline, bool use_internal_layout = false)
-   : PipelineInterface(layout, pipeline)
+  Pipeline(VkPipelineLayout layout, VkPipeline pipeline, VkPipelineBindPoint bind_point, bool use_internal_layout = false)
+   : PipelineInterface(layout, pipeline, bind_point)
    , use_internal_layout_{use_internal_layout}
   {}
 

--- a/src/framework/renderer/renderer.cc
+++ b/src/framework/renderer/renderer.cc
@@ -530,20 +530,35 @@ void Renderer::destroy_pipeline(Pipeline const& pipeline) const {
 
 // ----------------------------------------------------------------------------
 
-VkDescriptorSetLayout Renderer::create_descriptor_set_layout(DescriptorSetLayoutParams_t const& params) const {
-  assert(params.flags.empty() || (params.entries.size() == params.flags.size())); //
+VkDescriptorSetLayout Renderer::create_descriptor_set_layout(std::vector<DescriptorSetLayoutParams_t> const& params) const {
+  std::vector<VkDescriptorSetLayoutBinding> entries;
+  std::vector<VkDescriptorBindingFlags> flags;
+
+  entries.reserve(params.size());
+  flags.reserve(params.size());
+
+  for (auto const& param : params) {
+    entries.push_back({
+      .binding = param.binding,
+      .descriptorType = param.descriptorType,
+      .descriptorCount = param.descriptorCount,
+      .stageFlags = param.stageFlags,
+      .pImmutableSamplers = param.pImmutableSamplers,
+    });
+    flags.push_back(param.bindingFlags);
+  }
 
   VkDescriptorSetLayoutBindingFlagsCreateInfo const flags_create_info{
     .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO,
-    .bindingCount = static_cast<uint32_t>(params.flags.size()),
-    .pBindingFlags = params.flags.data(),
+    .bindingCount = static_cast<uint32_t>(flags.size()),
+    .pBindingFlags = flags.data(),
   };
   VkDescriptorSetLayoutCreateInfo const layout_create_info{
     .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
-    .pNext = params.flags.empty() ? nullptr : &flags_create_info,
+    .pNext = flags.empty() ? nullptr : &flags_create_info,
     .flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT, //
-    .bindingCount = static_cast<uint32_t>(params.entries.size()),
-    .pBindings = params.entries.data(),
+    .bindingCount = static_cast<uint32_t>(entries.size()),
+    .pBindings = entries.data(),
   };
 
   VkDescriptorSetLayout descriptor_set_layout;

--- a/src/framework/renderer/renderer.cc
+++ b/src/framework/renderer/renderer.cc
@@ -254,12 +254,18 @@ std::shared_ptr<Framebuffer> Renderer::create_framebuffer() const {
 
 void Renderer::destroy_pipeline_layout(VkPipelineLayout layout) const {
   vkDestroyPipelineLayout(device_, layout, nullptr);
-  // layout = VK_NULL_HANDLE;
 }
 
 // ----------------------------------------------------------------------------
 
 VkPipelineLayout Renderer::create_pipeline_layout(PipelineLayoutDescriptor_t const& params) const {
+  for (size_t i = 1u; i < params.pushConstantRanges.size(); ++i) {
+    if (params.pushConstantRanges[i].offset == 0u) {
+      std::cerr << "[Warning] 'create_pipeline_layout' has constant ranges with no offsets." << std::endl << std::endl;
+      break;
+    }
+  }
+
   VkPipelineLayoutCreateInfo const pipeline_layout_create_info{
     .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
     .setLayoutCount = static_cast<uint32_t>(params.setLayouts.size()),

--- a/src/framework/renderer/renderer.h
+++ b/src/framework/renderer/renderer.h
@@ -76,7 +76,7 @@ class Renderer : public RTInterface {
 
   // --- Descriptor Set Layout ---
 
-  VkDescriptorSetLayout create_descriptor_set_layout(DescriptorSetLayoutParams_t const& params) const;
+  VkDescriptorSetLayout create_descriptor_set_layout(std::vector<DescriptorSetLayoutParams_t> const& params) const;
 
   void destroy_descriptor_set_layout(VkDescriptorSetLayout& layout) const;
 

--- a/src/framework/renderer/renderer.h
+++ b/src/framework/renderer/renderer.h
@@ -72,6 +72,9 @@ class Renderer : public RTInterface {
   Pipeline create_graphics_pipeline(PipelineLayoutDescriptor_t const& layout_desc, GraphicsPipelineDescriptor_t const& desc) const;
   Pipeline create_graphics_pipeline(GraphicsPipelineDescriptor_t const& desc) const;
 
+  void create_compute_pipelines(VkPipelineLayout pipeline_layout, std::vector<ShaderModule_t> const& modules, Pipeline *pipelines) const;
+  Pipeline create_compute_pipeline(VkPipelineLayout pipeline_layout, ShaderModule_t const& module) const;
+
   void destroy_pipeline(Pipeline const& pipeline) const;
 
   // --- Descriptor Set Layout ---

--- a/src/framework/utils/geometry.cc
+++ b/src/framework/utils/geometry.cc
@@ -535,8 +535,8 @@ void Geometry::MakeTorus(Geometry &geo, float major_radius, float minor_radius, 
 // ----------------------------------------------------------------------------
 
 void Geometry::MakePointListPlane(Geometry &geo, float size, uint32_t resx, uint32_t resy) {
-  uint32_t const ncols = (resx + 1u);
-  uint32_t const nrows = (resy + 1u);
+  uint32_t const ncols = resx;
+  uint32_t const nrows = resy;
   uint32_t const vertex_count = nrows * ncols;
 
   std::vector<Point_t> vertices(vertex_count);

--- a/src/samples/03_descriptor_set/main.cc
+++ b/src/samples/03_descriptor_set/main.cc
@@ -100,19 +100,17 @@ class SampleApp final : public Application {
       uint32_t const kDescSetUniformBinding = 0u;
 
       descriptor_set_layout_ = renderer_.create_descriptor_set_layout({
-        .entries = {
-          {
-            .binding = kDescSetUniformBinding,
-            .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-            .descriptorCount = 1u,
-            .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+        {
+          .binding = kDescSetUniformBinding,
+          .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          .descriptorCount = 1u,
+          .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+          .bindingFlags = {
+              VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT
+            | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT
+            | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT
+            ,
           },
-        },
-        .flags = {
-            VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT
-          | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT
-          | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT
-          ,
         },
       });
 

--- a/src/samples/03_descriptor_set/main.cc
+++ b/src/samples/03_descriptor_set/main.cc
@@ -273,11 +273,10 @@ class SampleApp final : public Application {
 
   VkDescriptorSetLayout descriptor_set_layout_{};
   VkDescriptorSet descriptor_set_{};
+  shader_interop::PushConstant push_constant_{};
 
   VkPipelineLayout pipeline_layout_{};
   Pipeline graphics_pipeline_{};
-
-  shader_interop::PushConstant push_constant_{};
 };
 
 // ----------------------------------------------------------------------------

--- a/src/samples/04_texturing/main.cc
+++ b/src/samples/04_texturing/main.cc
@@ -92,26 +92,21 @@ class SampleApp final : public Application {
     /* Descriptor set. */
     {
       descriptor_set_layout_ = renderer_.create_descriptor_set_layout({
-        .entries = {
-          {
-            .binding = shader_interop::kDescriptorSetBinding_UniformBuffer,
-            .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-            .descriptorCount = 1u,
-            .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
-          },
-          {
-            .binding = shader_interop::kDescriptorSetBinding_Sampler,
-            .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-            .descriptorCount = 1u,
-            .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
-          },
+        {
+          .binding = shader_interop::kDescriptorSetBinding_UniformBuffer,
+          .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          .descriptorCount = 1u,
+          .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+          .bindingFlags = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT
+                        | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT
+                        | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT
         },
-        .flags = {
-            VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT
-          | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT
-          | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT
-          ,
-          VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT
+        {
+          .binding = shader_interop::kDescriptorSetBinding_Sampler,
+          .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          .descriptorCount = 1u,
+          .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+          .bindingFlags = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT,
         },
       });
 

--- a/src/samples/05_stencil_op/main.cc
+++ b/src/samples/05_stencil_op/main.cc
@@ -117,19 +117,15 @@ class SampleApp final : public Application {
     /* Descriptor set. */
     {
       descriptor_set_layout_ = renderer_.create_descriptor_set_layout({
-        .entries = {
-          {
-            .binding = shader_interop::kDescriptorSetBinding_UniformBuffer,
-            .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-            .descriptorCount = 1u,
-            .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
-          },
-        },
-        .flags = {
-            VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT
-          | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT
-          | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT
-          ,
+        {
+          .binding = shader_interop::kDescriptorSetBinding_UniformBuffer,
+          .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          .descriptorCount = 1u,
+          .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+          .bindingFlags = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT
+                        | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT
+                        | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT
+                        ,
         },
       });
 

--- a/src/samples/06_blend_op/main.cc
+++ b/src/samples/06_blend_op/main.cc
@@ -92,36 +92,32 @@ class SampleApp final : public Application {
       };
 
       graphics_.descriptor_set_layout = renderer_.create_descriptor_set_layout({
-        .entries = {
-          {
-            .binding = shader_interop::kDescriptorSetBinding_UniformBuffer,
-            .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-            .descriptorCount = 1u,
-            .stageFlags = VK_SHADER_STAGE_VERTEX_BIT
-                        | VK_SHADER_STAGE_COMPUTE_BIT
-                        ,
-          },
-          {
-            .binding = shader_interop::kDescriptorSetBinding_StorageBuffer_Position,
-            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-            .descriptorCount = 1u,
-            .stageFlags = VK_SHADER_STAGE_VERTEX_BIT
-                        | VK_SHADER_STAGE_COMPUTE_BIT
-                        ,
-          },
-          {
-            .binding = shader_interop::kDescriptorSetBinding_StorageBuffer_Index,
-            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-            .descriptorCount = 1u,
-            .stageFlags = VK_SHADER_STAGE_VERTEX_BIT
-                        | VK_SHADER_STAGE_COMPUTE_BIT
-                        ,
-          },
+        {
+          .binding = shader_interop::kDescriptorSetBinding_UniformBuffer,
+          .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          .descriptorCount = 1u,
+          .stageFlags = VK_SHADER_STAGE_VERTEX_BIT
+                      | VK_SHADER_STAGE_COMPUTE_BIT
+                      ,
+          .bindingFlags = kDefaultDescBindingFlags,
         },
-        .flags = {
-          kDefaultDescBindingFlags,
-          kDefaultDescBindingFlags,
-          kDefaultDescBindingFlags,
+        {
+          .binding = shader_interop::kDescriptorSetBinding_StorageBuffer_Position,
+          .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          .descriptorCount = 1u,
+          .stageFlags = VK_SHADER_STAGE_VERTEX_BIT
+                      | VK_SHADER_STAGE_COMPUTE_BIT
+                      ,
+          .bindingFlags = kDefaultDescBindingFlags,
+        },
+        {
+          .binding = shader_interop::kDescriptorSetBinding_StorageBuffer_Index,
+          .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          .descriptorCount = 1u,
+          .stageFlags = VK_SHADER_STAGE_VERTEX_BIT
+                      | VK_SHADER_STAGE_COMPUTE_BIT
+                      ,
+          .bindingFlags = kDefaultDescBindingFlags,
         },
       });
 

--- a/src/samples/06_blend_op/main.cc
+++ b/src/samples/06_blend_op/main.cc
@@ -223,7 +223,6 @@ class SampleApp final : public Application {
 
     auto cmd = renderer_.begin_frame();
     {
-      /* As the pipeline shared the same layout, we can bind them just once directly. */
       cmd.bind_descriptor_set(graphics_.descriptor_set, graphics_.pipeline_layout, VK_SHADER_STAGE_VERTEX_BIT);
 
       graphics_.push_constant.model.worldMatrix = world_matrix;

--- a/src/samples/06_blend_op/main.cc
+++ b/src/samples/06_blend_op/main.cc
@@ -193,6 +193,7 @@ class SampleApp final : public Application {
         },
         .primitive = {
           .topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+          /* We disable culling as we let the billboard particles face whatever direction. */
           // .cullMode = VK_CULL_MODE_BACK_BIT,
         },
       });

--- a/src/samples/06_blend_op/shaders/glsl/simple.vert.glsl
+++ b/src/samples/06_blend_op/shaders/glsl/simple.vert.glsl
@@ -50,33 +50,35 @@ const vec2 kLocalTexCoords[6] = vec2[](
   vec2(1.0, 1.0)
 );
 
+const float kTwoPi = 6.28318530718;
+
+const vec2 kSpriteSize = vec2(0.035);
+
 // ----------------------------------------------------------------------------
 
 layout(location = 0) out vec2 vTexCoord;
 
 // ----------------------------------------------------------------------------
 
-const float kTwoPi = 6.28318530718;
-const vec2 kSpriteSize = vec2(0.035);
-
 void main() {
   mat4 worldMatrix = pushConstant.model.worldMatrix;
   mat4 viewMatrix = uData.scene.camera.viewMatrix;
-
   mat4 viewProj = uData.scene.camera.projectionMatrix
                 * viewMatrix
                 ;
 
   int primitive_id = gl_InstanceIndex;
   int vertex_id = gl_VertexIndex;
+
   vec3 center = Positions[Indices[primitive_id]].xyz;
+  vec2 quad_offset = kSpriteSize * kLocalOffsets[vertex_id];
 
   //---------
 
   /// NOTEs
-  /// Direct particle simulation on the vertex shader is possible when we don't
-  /// to process them between frame (eg. sort them for alpha blending or manage
-  /// their lifecycle) .
+  /// One pass particle simulation on the vertex shader is possible when we don't
+  /// need to process them between frame (eg. sort them for alpha blending or manage
+  /// their lifecycle).
 
   /* Move Points on a sphere. */
   float phi = center.x * kTwoPi * (1.0f - 1.0f/512.0f);
@@ -120,7 +122,6 @@ void main() {
   quad_up    = normalize(cross(quad_right, quad_front));
 #endif
 
-  vec2 quad_offset = kSpriteSize * kLocalOffsets[vertex_id];
   vec3 vertex_offset = quad_right * quad_offset.x
                      + quad_up * quad_offset.y
                      ;

--- a/src/samples/06_blend_op/shaders/glsl/simple.vert.glsl
+++ b/src/samples/06_blend_op/shaders/glsl/simple.vert.glsl
@@ -75,10 +75,14 @@ void main() {
 
   //---------
 
-  /// NOTEs
+  /* Simulate particles. */
+  ///
   /// One pass particle simulation on the vertex shader is possible when we don't
-  /// need to process them between frame (eg. sort them for alpha blending or manage
-  /// their lifecycle).
+  /// need to process them between frame (eg. sorting them for alpha blending or
+  /// to manage their lifecycle).
+  ///
+  /// It's perfect to render per-vertex attributes, like normals.
+  ///
 
   /* Move Points on a sphere. */
   float phi = center.x * kTwoPi * (1.0f - 1.0f/512.0f);
@@ -90,19 +94,10 @@ void main() {
     ct * sin(phi)
   );
 
-#if 0
-  normal += 2.5 * vec3(
-    sin(theta),
-    0.8 * cos(2.0f*theta),
-    ct
-  );
-#else
   center += normal;
-#endif
 
   /* Move along the normal */
   float factor = 0.2f * sin(8.0f * dot(center, center) + 0.75f * pushConstant.time);
-  // factor *= cos(0.2f * phi + 0.15f * pushConstant.time);
   center = factor * normal;
 
   //---------

--- a/src/samples/07_compute/main.cc
+++ b/src/samples/07_compute/main.cc
@@ -1,0 +1,532 @@
+/* -------------------------------------------------------------------------- */
+//
+//    07 - Hello Compute
+//
+//  Where we simulate & sort alpha blended particles on compute shaders,
+//  using a simple bitonic sorting algorithm.
+//
+/* -------------------------------------------------------------------------- */
+
+#include "framework/application.h"
+#include "framework/utils/geometry.h"
+
+namespace shader_interop {
+#include "shaders/interop.h"
+}
+
+/* -------------------------------------------------------------------------- */
+
+class SampleApp final : public Application {
+ public:
+  // The sorting algorithm used support power-of-two sized buffer only.
+  static constexpr uint32_t kPointGridSize{ 512u };
+  static constexpr uint32_t kPointGridResolution{ kPointGridSize * kPointGridSize };
+
+  using HostData_t = shader_interop::UniformData;
+
+  enum {
+    Compute_Simulation = 0,
+    Compute_FillIndices,
+    Compute_DotProduct,
+    Compute_SortIndices,
+
+    Compute_kCount,
+  };
+
+  struct Mesh_t {
+    Geometry geo;
+    Buffer_t vertex;
+    Buffer_t index;
+  };
+
+ public:
+  SampleApp() = default;
+  ~SampleApp() {}
+
+ private:
+  bool setup() final {
+    wm_->setTitle("07 - Nouvelles Vagues");
+
+    renderer_.set_color_clear_value({{ 0.95f, 0.85f, 0.83f, 1.0f }});
+
+    allocator_ = context_.get_resource_allocator();
+
+    /* Initialize the scene data. */
+    host_data_.scene.camera = {
+      .viewMatrix = linalg::lookat_matrix(
+        vec3f(13.0f, 4.5f, 13.0f),
+        vec3f(0.0f, 0.0f, 0.0f),
+        vec3f(0.0f, 1.0f, 0.0f)
+      ),
+      .projectionMatrix = linalg::perspective_matrix(
+        lina::radians(60.0f),
+        static_cast<float>(viewport_size_.width) / static_cast<float>(viewport_size_.height),
+        0.01f,
+        500.0f,
+        linalg::neg_z,
+        linalg::zero_to_one
+      ),
+    };
+
+    /* Device buffers with initial data. */
+    {
+      auto cmd = context_.create_transient_command_encoder();
+
+      uniform_buffer_ = cmd.create_buffer_and_upload(
+        &host_data_, sizeof(host_data_),
+        VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT
+      );
+
+      /* We need to double the size of the device buffers as we
+       * will use the vertex one as backup positions and the index one as
+       * it as a ping-pong buffer to sort indices between frames. */
+      {
+        auto &mesh = point_grid_;
+        Geometry::MakePointListPlane(mesh.geo, 12.0f, kPointGridSize, kPointGridSize);
+
+        vertex_buffer_bytesize_ = mesh.geo.get_vertices().size();
+        mesh.vertex = cmd.create_buffer_and_upload(
+          mesh.geo.get_vertices(),
+          VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+          vertex_buffer_bytesize_, 2u * vertex_buffer_bytesize_
+        );
+
+        index_buffer_bytesize_ = mesh.geo.get_indices().size();
+        mesh.index = cmd.create_buffer_and_upload(
+          mesh.geo.get_indices(),
+          VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+          0u, 2u * index_buffer_bytesize_
+        );
+      }
+
+      context_.finish_transient_command_encoder(cmd);
+
+      /* Buffer used to store the dot product of particles toward the view direction. */
+      compute_.dot_product_buffer = allocator_->create_buffer(
+        point_grid_.geo.get_vertex_count() * sizeof(float),
+        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+        VMA_MEMORY_USAGE_GPU_ONLY
+      );
+    }
+
+    /* Create the shared descriptor set and its layout. */
+    {
+      VkDescriptorBindingFlags const kDefaultDescBindingFlags{
+          VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT
+        | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT
+        | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT
+      };
+
+      descriptor_set_layout_ = renderer_.create_descriptor_set_layout({
+        {
+          .binding = shader_interop::kDescriptorSetBinding_UniformBuffer,
+          .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          .descriptorCount = 1u,
+          .stageFlags = VK_SHADER_STAGE_VERTEX_BIT
+                      | VK_SHADER_STAGE_COMPUTE_BIT
+                      ,
+          .bindingFlags = kDefaultDescBindingFlags,
+        },
+        {
+          .binding = shader_interop::kDescriptorSetBinding_StorageBuffer_Position,
+          .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          .descriptorCount = 1u,
+          .stageFlags = VK_SHADER_STAGE_VERTEX_BIT
+                      | VK_SHADER_STAGE_COMPUTE_BIT
+                      ,
+          .bindingFlags = kDefaultDescBindingFlags,
+        },
+        {
+          .binding = shader_interop::kDescriptorSetBinding_StorageBuffer_Index,
+          .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          .descriptorCount = 2u,
+          .stageFlags = VK_SHADER_STAGE_VERTEX_BIT
+                      | VK_SHADER_STAGE_COMPUTE_BIT
+                      ,
+          .bindingFlags = kDefaultDescBindingFlags,
+        },
+        {
+          .binding = shader_interop::kDescriptorSetBinding_StorageBuffer_DotProduct,
+          .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          .descriptorCount = 1u,
+          .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT
+                      ,
+          .bindingFlags = kDefaultDescBindingFlags,
+        },
+      });
+
+      descriptor_set_ = renderer_.create_descriptor_set(descriptor_set_layout_, {
+        {
+          .binding = shader_interop::kDescriptorSetBinding_UniformBuffer,
+          .type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          .resource = { .buffer = { uniform_buffer_.buffer } }
+        },
+        {
+          .binding = shader_interop::kDescriptorSetBinding_StorageBuffer_Position,
+          .type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          .resource = { .buffer = { point_grid_.vertex.buffer } }
+        },
+        {
+          .binding = shader_interop::kDescriptorSetBinding_StorageBuffer_Index,
+          .type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          .resource = { .buffer = { point_grid_.index.buffer } }
+        },
+        {
+          .binding = shader_interop::kDescriptorSetBinding_StorageBuffer_DotProduct,
+          .type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          .resource = { .buffer = { compute_.dot_product_buffer.buffer } }
+        },
+      });
+    }
+
+    /* Create a shared pipeline layout. */
+    pipeline_layout_ = renderer_.create_pipeline_layout({
+      .setLayouts = { descriptor_set_layout_ },
+      .pushConstantRanges = {
+        {
+          .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+          .offset = offsetof(shader_interop::PushConstant, graphics),
+          .size = sizeof(push_constant_.graphics),
+        },
+        {
+          .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+          .offset = offsetof(shader_interop::PushConstant, compute),
+          .size = sizeof(push_constant_.compute),
+        }
+      },
+    });
+
+    /* Create the compute pipelines. */
+    {
+      auto shaders{context_.create_shader_modules(COMPILED_SHADERS_DIR "sort/", {
+        "simulation.comp.glsl",
+        "fill_indices.comp.glsl",
+        "calculate_dot_product.comp.glsl",
+        "sort_indices.comp.glsl",
+      })};
+
+      std::vector<VkComputePipelineCreateInfo> pipeline_infos(shaders.size(), {
+        .sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
+        .stage = {
+          .sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+          .stage  = VK_SHADER_STAGE_COMPUTE_BIT,
+          .module = VK_NULL_HANDLE,
+          .pName  = "main",
+        },
+        .layout = pipeline_layout_,
+      });
+      for (size_t i = 0; i < shaders.size(); ++i) {
+        pipeline_infos[i].stage.module = shaders[i].module;
+      }
+
+      CHECK_VK(vkCreateComputePipelines(
+        context_.get_device(), {}, static_cast<uint32_t>(pipeline_infos.size()), pipeline_infos.data(), nullptr, compute_.pipelines.data()
+      ));
+
+      context_.release_shader_modules(shaders);
+    }
+
+    /* Create the graphics pipeline. */
+    {
+      auto shaders{context_.create_shader_modules(COMPILED_SHADERS_DIR, {
+        "simple.vert.glsl",
+        "simple.frag.glsl",
+      })};
+
+      graphics_.pipeline = renderer_.create_graphics_pipeline(pipeline_layout_, {
+        .vertex = {
+          .module = shaders[0u].module,
+        },
+        .fragment = {
+          .module = shaders[1u].module,
+          .targets = {
+            {
+              .format = renderer_.get_color_attachment().format,
+              .writeMask = VK_COLOR_COMPONENT_R_BIT
+                         | VK_COLOR_COMPONENT_G_BIT
+                         | VK_COLOR_COMPONENT_B_BIT
+                         | VK_COLOR_COMPONENT_A_BIT
+                         ,
+              .blend = {
+                .enable = VK_TRUE,
+                .color = {
+                  .operation = VK_BLEND_OP_ADD,
+                  .srcFactor = VK_BLEND_FACTOR_SRC_ALPHA,
+                  .dstFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+                },
+                .alpha =  {
+                  .operation = VK_BLEND_OP_ADD,
+                  .srcFactor = VK_BLEND_FACTOR_SRC_ALPHA,
+                  .dstFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+                },
+              }
+            }
+          },
+        },
+        .depthStencil = {
+          .format = renderer_.get_depth_stencil_attachment().format, //
+        },
+        .primitive = {
+          .topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
+          .cullMode = VK_CULL_MODE_BACK_BIT,
+        },
+      });
+
+      context_.release_shader_modules(shaders);
+    }
+
+    return true;
+  }
+
+  void release() final {
+    for (auto pipeline : compute_.pipelines) {
+      vkDestroyPipeline(context_.get_device(), pipeline, nullptr);
+    }
+    renderer_.destroy_pipeline(graphics_.pipeline);
+
+    renderer_.destroy_descriptor_set_layout(descriptor_set_layout_);
+    renderer_.destroy_pipeline_layout(pipeline_layout_);
+
+    allocator_->destroy_buffer(compute_.dot_product_buffer);
+    allocator_->destroy_buffer(point_grid_.index);
+    allocator_->destroy_buffer(point_grid_.vertex);
+    allocator_->destroy_buffer(uniform_buffer_);
+  }
+
+  void frame() final {
+    mat4 const world_matrix(
+      linalg::mul(
+        lina::rotation_matrix_y(0.15f * get_frame_time()),
+        linalg::scaling_matrix(vec3(2.0f))
+      )
+    );
+
+
+    auto cmd = renderer_.begin_frame();
+    {
+      /* Bind the shared descriptor set. */
+      cmd.bind_descriptor_set(
+        descriptor_set_,
+        pipeline_layout_,
+        VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_COMPUTE_BIT
+      );
+
+      /* Simulate & Sort particles */
+      {
+        VkBufferMemoryBarrier barrier{
+          .sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
+          .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT,
+          .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
+          .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+          .offset = 0,
+          .size = VK_WHOLE_SIZE,
+        };
+
+        auto const nelems = point_grid_.geo.get_vertex_count();
+
+        uint32_t group_x = 0u;
+
+        auto getGroupSize{ [](uint32_t const totalSize, uint32_t const blockSize) -> uint32_t {
+          return (totalSize + blockSize - 1u) / blockSize;
+        }};
+
+        // -------
+
+        push_constant_.compute.model.worldMatrix = world_matrix; //
+        push_constant_.compute.time = get_frame_time();
+        push_constant_.compute.numElems = nelems;
+
+        cmd.push_constant(
+          push_constant_.compute,
+          pipeline_layout_,
+          VK_SHADER_STAGE_COMPUTE_BIT,
+          offsetof(shader_interop::PushConstant, compute)
+        );
+
+        /// 1) Simulate a simple particle system.
+        vkCmdBindPipeline(cmd.get_handle(), VK_PIPELINE_BIND_POINT_COMPUTE, compute_.pipelines.at(Compute_Simulation));
+        {
+          group_x = getGroupSize(nelems, shader_interop::kCompute_Simulation_kernelSize_x);
+          vkCmdDispatch(cmd.get_handle(), group_x, 1u, 1u);
+        }
+
+        barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        barrier.buffer = point_grid_.vertex.buffer;
+        vkCmdPipelineBarrier(
+          cmd.get_handle(),
+          VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+          VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+          0, 0, nullptr, 1, &barrier, 0, nullptr
+        );
+
+        /// 2) Fill the first part of indices buffer with continuous indices.
+        vkCmdBindPipeline(cmd.get_handle(), VK_PIPELINE_BIND_POINT_COMPUTE, compute_.pipelines.at(Compute_FillIndices));
+        {
+          group_x = getGroupSize(nelems, shader_interop::kCompute_FillIndex_kernelSize_x);
+          vkCmdDispatch(cmd.get_handle(), group_x, 1u, 1u);
+        }
+
+        barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        barrier.buffer = point_grid_.index.buffer;
+        vkCmdPipelineBarrier(
+          cmd.get_handle(),
+          VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+          VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+          0, 0, nullptr, 1, &barrier, 0, nullptr
+        );
+
+        /// 3) Compute the particles dot product against the camera direction.
+        vkCmdBindPipeline(cmd.get_handle(), VK_PIPELINE_BIND_POINT_COMPUTE, compute_.pipelines.at(Compute_DotProduct));
+        {
+          group_x = getGroupSize(nelems, shader_interop::kCompute_DotProduct_kernelSize_x);
+          vkCmdDispatch(cmd.get_handle(), group_x, 1u, 1u);
+
+          barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+          barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+          barrier.buffer = compute_.dot_product_buffer.buffer;
+          vkCmdPipelineBarrier(
+            cmd.get_handle(),
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            0, 0, nullptr, 1, &barrier, 0, nullptr
+          );
+
+          // (to use instead)
+          // vkCmdPipelineBarrier2(command_buffer, &dependency_info);
+        }
+
+        /// 2) Sort indices via their dot products using a simple bitonic sort.
+        vkCmdBindPipeline(cmd.get_handle(), VK_PIPELINE_BIND_POINT_COMPUTE, compute_.pipelines.at(Compute_SortIndices));
+        {
+          uint32_t index_buffer_binding = 0u;
+          uint32_t const index_buffer_offset = point_grid_.geo.get_index_count();
+
+          // Get trailing bits count.
+          uint32_t nsteps = 0u;
+          for (uint32_t i = nelems; i > 1u; i >>= 1u) {
+            ++nsteps;
+          }
+
+          for (uint32_t stage = 0u; stage < nsteps; ++stage)
+          {
+            uint32_t const max_block_width{ 2u << stage };
+            for (uint32_t pass = 0u; pass <= stage; ++pass)
+            {
+              uint32_t const block_width{ 2u << (stage - pass) };
+              uint32_t const read_offset{ index_buffer_offset * index_buffer_binding };
+              uint32_t const write_offset{ index_buffer_offset * (index_buffer_binding ^ 1u) };
+
+              push_constant_.compute.readOffset = read_offset;
+              push_constant_.compute.writeOffset = write_offset;
+              push_constant_.compute.blockWidth = block_width;
+              push_constant_.compute.maxBlockWidth = max_block_width;
+              cmd.push_constant(
+                push_constant_.compute,
+                pipeline_layout_,
+                VK_SHADER_STAGE_COMPUTE_BIT,
+                offsetof(shader_interop::PushConstant, compute)
+              );
+
+              group_x = getGroupSize(nelems / 2u, shader_interop::kCompute_SortIndex_kernelSize_x);
+              vkCmdDispatch(cmd.get_handle(), group_x, 1u, 1u);
+
+              barrier.buffer = point_grid_.index.buffer;
+              barrier.size = index_buffer_bytesize_;
+
+              barrier.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+              barrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+              barrier.offset = read_offset * sizeof(uint32_t);
+              vkCmdPipelineBarrier(
+                cmd.get_handle(),
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                0, 0, nullptr, 1, &barrier, 0, nullptr
+              );
+
+              barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+              barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+              barrier.offset = write_offset * sizeof(uint32_t);
+              vkCmdPipelineBarrier(
+                cmd.get_handle(),
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                0, 0, nullptr, 1, &barrier, 0, nullptr
+              );
+
+              index_buffer_binding ^= 1u;
+            }
+          }
+        }
+
+        barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+        barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        barrier.buffer = point_grid_.index.buffer;
+        barrier.offset = 0;
+        barrier.size = VK_WHOLE_SIZE;
+        vkCmdPipelineBarrier(
+          cmd.get_handle(),
+          VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+          VK_PIPELINE_STAGE_VERTEX_SHADER_BIT,
+          0, 0, nullptr, 1, &barrier, 0, nullptr
+        );
+      }
+
+      /* Render */
+      auto pass = cmd.begin_rendering();
+      {
+        pass.set_viewport_scissor(viewport_size_);
+
+        pass.set_pipeline(graphics_.pipeline);
+
+        push_constant_.graphics.model.worldMatrix = world_matrix;
+        pass.push_constant(
+          push_constant_.graphics,
+          VK_SHADER_STAGE_VERTEX_BIT,
+          offsetof(shader_interop::PushConstant, graphics)
+        );
+
+        pass.draw(4u, point_grid_.geo.get_vertex_count());
+      }
+      cmd.end_rendering();
+    }
+    renderer_.end_frame();
+  }
+
+ private:
+  std::shared_ptr<ResourceAllocator> allocator_;
+
+  HostData_t host_data_{};
+
+  Buffer_t uniform_buffer_{};
+  Mesh_t point_grid_{};
+
+  uint32_t vertex_buffer_bytesize_{};
+  uint32_t index_buffer_bytesize_{};
+
+  VkDescriptorSetLayout descriptor_set_layout_{};
+  VkDescriptorSet descriptor_set_{};
+
+  shader_interop::PushConstant push_constant_{};
+  VkPipelineLayout pipeline_layout_{};
+
+  struct {
+    Pipeline pipeline{};
+  } graphics_;
+
+  struct {
+    Buffer_t dot_product_buffer{};
+    std::array<VkPipeline, Compute_kCount> pipelines{}; //
+  } compute_;
+
+};
+
+// ----------------------------------------------------------------------------
+
+int main(int argc, char *argv[]) {
+  return SampleApp().run();
+}
+
+/* -------------------------------------------------------------------------- */

--- a/src/samples/07_compute/main.cc
+++ b/src/samples/07_compute/main.cc
@@ -19,7 +19,7 @@ namespace shader_interop {
 class SampleApp final : public Application {
  public:
   // The sorting algorithm used support power-of-two sized buffer only.
-  static constexpr uint32_t kPointGridSize{ 512u };
+  static constexpr uint32_t kPointGridSize{ 1024u };
   static constexpr uint32_t kPointGridResolution{ kPointGridSize * kPointGridSize };
 
   using HostData_t = shader_interop::UniformData;
@@ -54,7 +54,7 @@ class SampleApp final : public Application {
     /* Initialize the scene data. */
     host_data_.scene.camera = {
       .viewMatrix = linalg::lookat_matrix(
-        vec3f(13.0f, 4.5f, 13.0f),
+        vec3f(15.0f, 5.0f, 15.0f),
         vec3f(0.0f, 0.0f, 0.0f),
         vec3f(0.0f, 1.0f, 0.0f)
       ),
@@ -79,10 +79,14 @@ class SampleApp final : public Application {
 
       /* We need to double the size of the device buffers as we
        * will use the vertex one as backup positions and the index one as
-       * it as a ping-pong buffer to sort indices between frames. */
+       * a ping-pong buffer to sort indices between frames.
+       *
+       * In a more complex case it would be more interesting to reset the particles
+       * via a compute shader, but here it cost about ~4Mb more per 256k particles.
+       */
       {
         auto &mesh = point_grid_;
-        Geometry::MakePointListPlane(mesh.geo, 12.0f, kPointGridSize, kPointGridSize);
+        Geometry::MakePointListPlane(mesh.geo, 16.0f, kPointGridSize, kPointGridSize);
 
         vertex_buffer_bytesize_ = mesh.geo.get_vertices().size();
         mesh.vertex = cmd.create_buffer_and_upload(
@@ -296,7 +300,7 @@ class SampleApp final : public Application {
   void frame() final {
     mat4 const world_matrix(
       linalg::mul(
-        lina::rotation_matrix_y(0.15f * get_frame_time()),
+        lina::rotation_matrix_y(0.05f * get_frame_time()),
         linalg::scaling_matrix(vec3(2.0f))
       )
     );

--- a/src/samples/07_compute/shaders/glsl/simple.frag.glsl
+++ b/src/samples/07_compute/shaders/glsl/simple.frag.glsl
@@ -13,14 +13,16 @@ layout(location = 1) in vec3 vPosition;
 layout(location = 0) out vec4 fragColor;
 
 void main() {
-  float borderAlpha = 1.0 - smoothstep(180, 220, dot(vPosition, vPosition));
+  float borderAlpha = 1.0 - (
+    smoothstep(202, 212, dot(vPosition, vPosition))
+  );
 
   vec2 pt = 2.0f * (vTexCoord - 0.5f);
   float d = 1.0f - abs(dot(pt, pt));
   float alpha = borderAlpha * smoothstep(0.65f, 0.85f, d);
 
   fragColor = vec4(vec3(d), alpha);
-  fragColor *= d * vec4(0.2, 0.65  * (0.75 + 0.25 * vPosition.y), 0.95 + 0.05 * vPosition.y, 0.25);
+  fragColor *= d * vec4(0.15, 0.70  * (0.75 + 0.35 * vPosition.y), 0.95 + 0.05 * vPosition.y, 0.25);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/samples/07_compute/shaders/glsl/simple.frag.glsl
+++ b/src/samples/07_compute/shaders/glsl/simple.frag.glsl
@@ -1,0 +1,27 @@
+#version 460
+#extension GL_GOOGLE_include_directive : require
+
+// ----------------------------------------------------------------------------
+
+#include "../interop.h"
+
+// ----------------------------------------------------------------------------
+
+layout(location = 0) in vec2 vTexCoord;
+
+layout(location = 0) out vec4 fragColor;
+
+void main() {
+  vec2 pt = 2.0f * (vTexCoord - 0.5f);
+
+  vec2 shamble = vec2(0.5*sin(2.9*pt.y), 0.5*cos(2.4*pt.x));
+
+  float d = 1.0f - abs(dot(pt, pt));
+  float alpha = smoothstep(0.75f, 0.85f, d);
+
+  fragColor = vec4(vec3(d), alpha);
+
+  fragColor *= d * vec4(0.25, 0.5, 0.95, 0.175);
+}
+
+// ----------------------------------------------------------------------------

--- a/src/samples/07_compute/shaders/glsl/simple.frag.glsl
+++ b/src/samples/07_compute/shaders/glsl/simple.frag.glsl
@@ -8,20 +8,19 @@
 // ----------------------------------------------------------------------------
 
 layout(location = 0) in vec2 vTexCoord;
+layout(location = 1) in vec3 vPosition;
 
 layout(location = 0) out vec4 fragColor;
 
 void main() {
+  float borderAlpha = 1.0 - smoothstep(180, 220, dot(vPosition, vPosition));
+
   vec2 pt = 2.0f * (vTexCoord - 0.5f);
-
-  vec2 shamble = vec2(0.5*sin(2.9*pt.y), 0.5*cos(2.4*pt.x));
-
   float d = 1.0f - abs(dot(pt, pt));
-  float alpha = smoothstep(0.75f, 0.85f, d);
+  float alpha = borderAlpha * smoothstep(0.65f, 0.85f, d);
 
   fragColor = vec4(vec3(d), alpha);
-
-  fragColor *= d * vec4(0.25, 0.5, 0.95, 0.175);
+  fragColor *= d * vec4(0.2, 0.65  * (0.75 + 0.25 * vPosition.y), 0.95 + 0.05 * vPosition.y, 0.25);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/samples/07_compute/shaders/glsl/simple.vert.glsl
+++ b/src/samples/07_compute/shaders/glsl/simple.vert.glsl
@@ -1,0 +1,89 @@
+#version 460
+#extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_scalar_block_layout : require
+
+// ----------------------------------------------------------------------------
+
+#include "../interop.h"
+
+// ----------------------------------------------------------------------------
+
+layout(scalar, set = 0, binding = kDescriptorSetBinding_UniformBuffer)
+uniform UBO_ {
+  UniformData uData;
+};
+
+layout(scalar, set = 0, binding = kDescriptorSetBinding_StorageBuffer_Position)
+readonly buffer SBO_positions_ {
+  vec4 Positions[];
+};
+
+layout(scalar, set = 0, binding = kDescriptorSetBinding_StorageBuffer_Index)
+readonly buffer SBO_indices_ {
+  uint Indices[];
+};
+
+layout(push_constant, scalar)
+uniform PushConstant_ {
+  PushConstant_Graphics pushConstant;
+};
+
+// ----------------------------------------------------------------------------
+
+const vec2 kLocalOffsets[4] = vec2[](
+  vec2(-0.5,  0.5),
+  vec2(-0.5, -0.5),
+  vec2( 0.5,  0.5),
+  vec2( 0.5, -0.5)
+);
+
+const vec2 kLocalTexCoords[4] = vec2[](
+  vec2(0.0, 1.0),
+  vec2(0.0, 0.0),
+  vec2(1.0, 1.0),
+  vec2(1.0, 0.0)
+);
+
+// ----------------------------------------------------------------------------
+
+layout(location = 0) out vec2 vTexCoord;
+
+// ----------------------------------------------------------------------------
+
+void main() {
+  mat4 worldMatrix = pushConstant.model.worldMatrix;
+
+  mat4 viewMatrix = uData.scene.camera.viewMatrix;
+
+  mat4 viewProj = uData.scene.camera.projectionMatrix
+                * viewMatrix
+                ;
+
+  // --------------------------------
+
+  int primitive_id = gl_InstanceIndex;
+  int vertex_id = gl_VertexIndex;
+
+  vec4 particle = Positions[Indices[primitive_id]];
+  vec3 center = particle.xyz;
+  vec2 spriteSize = vec2(0.15f * particle.w);
+
+  vec2 quad_offset = spriteSize * kLocalOffsets[vertex_id];
+
+  /* Create a 'billboard' quad from the particle position. */
+  vec3 quad_right = normalize(vec3(viewMatrix[0].x, viewMatrix[1].x, viewMatrix[2].x));
+  vec3 quad_up    = normalize(vec3(viewMatrix[0].y, viewMatrix[1].y, viewMatrix[2].y));
+
+  vec3 vertex_offset = quad_right * quad_offset.x
+                     + quad_up * quad_offset.y
+                     ;
+
+  vec3 worldPos = vec3(worldMatrix * vec4(center, 1.0f)) + vertex_offset;
+
+  // --------------------------------
+
+  gl_Position = viewProj * vec4(worldPos, 1.0f);
+  vTexCoord = kLocalTexCoords[vertex_id];
+}
+
+// ----------------------------------------------------------------------------

--- a/src/samples/07_compute/shaders/glsl/simple.vert.glsl
+++ b/src/samples/07_compute/shaders/glsl/simple.vert.glsl
@@ -47,6 +47,7 @@ const vec2 kLocalTexCoords[4] = vec2[](
 // ----------------------------------------------------------------------------
 
 layout(location = 0) out vec2 vTexCoord;
+layout(location = 1) out vec3 vPosition;
 
 // ----------------------------------------------------------------------------
 
@@ -77,13 +78,14 @@ void main() {
   vec3 vertex_offset = quad_right * quad_offset.x
                      + quad_up * quad_offset.y
                      ;
-
-  vec3 worldPos = vec3(worldMatrix * vec4(center, 1.0f)) + vertex_offset;
+  const vec3 worldPos = vec3(worldMatrix * vec4(center, 1.0f)) + vertex_offset;
 
   // --------------------------------
 
-  gl_Position = viewProj * vec4(worldPos, 1.0f);
+  vPosition = worldPos;
   vTexCoord = kLocalTexCoords[vertex_id];
+
+  gl_Position = viewProj * vec4(worldPos, 1.0f);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/samples/07_compute/shaders/glsl/sort/calculate_dot_product.comp.glsl
+++ b/src/samples/07_compute/shaders/glsl/sort/calculate_dot_product.comp.glsl
@@ -1,0 +1,53 @@
+#version 460
+#extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_scalar_block_layout : require
+
+#include "../../interop.h"
+
+// ----------------------------------------------------------------------------
+
+layout(scalar, set = 0, binding = kDescriptorSetBinding_UniformBuffer)
+uniform UBO_ {
+  UniformData uData;
+};
+
+layout(scalar, set = 0, binding = kDescriptorSetBinding_StorageBuffer_Position)
+readonly buffer SBO_positions_ {
+  vec4 WorldPositions[];
+};
+
+layout(scalar, set = 0, binding = kDescriptorSetBinding_StorageBuffer_DotProduct)
+writeonly buffer SBO_dot_products_ {
+  float DotProducts[];
+};
+
+layout(push_constant, scalar)
+uniform PushConstant_ {
+  layout(offset = 64) PushConstant_Compute pushConstant;
+};
+
+// The default front of camera in view space.
+const vec3 kTargetVS = vec3(0.0f, 0.0f, -1.0f);
+
+// ----------------------------------------------------------------------------
+
+layout(local_size_x = kCompute_DotProduct_kernelSize_x) in;
+
+void main() {
+  const uint gid = gl_GlobalInvocationID.x;
+
+  if (gid >= pushConstant.numElems) {
+    return;
+  }
+
+  // Transform a particle's position to view space.
+  vec4 positionVS = uData.scene.camera.viewMatrix
+                  * pushConstant.model.worldMatrix
+                  * vec4(WorldPositions[gid].xyz, 1.0f)
+                  ;
+
+  // Distance of the particle from the camera.
+  DotProducts[gid] = dot(kTargetVS, positionVS.xyz);
+}
+
+// ----------------------------------------------------------------------------

--- a/src/samples/07_compute/shaders/glsl/sort/fill_indices.comp.glsl
+++ b/src/samples/07_compute/shaders/glsl/sort/fill_indices.comp.glsl
@@ -1,0 +1,35 @@
+#version 460
+#extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_scalar_block_layout : require
+
+//-----------------------------------------------------------------------------
+
+#include "../../interop.h"
+
+//-----------------------------------------------------------------------------
+
+layout(scalar, binding = kDescriptorSetBinding_StorageBuffer_Index)
+writeonly buffer SBO_indices_ {
+  uint Indices[];
+};
+
+layout(push_constant, scalar)
+uniform PushConstant_ {
+  layout(offset = 64) PushConstant_Compute pushConstant;
+};
+
+//-----------------------------------------------------------------------------
+
+layout(local_size_x = kCompute_FillIndex_kernelSize_x) in;
+
+void main() {
+  const uint gid = gl_GlobalInvocationID.x;
+
+  if (gid >= pushConstant.numElems) {
+    return;
+  }
+
+  Indices[gid] = gid;
+}
+
+//-----------------------------------------------------------------------------

--- a/src/samples/07_compute/shaders/glsl/sort/simulation.comp.glsl
+++ b/src/samples/07_compute/shaders/glsl/sort/simulation.comp.glsl
@@ -1,0 +1,73 @@
+#version 460
+#extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_scalar_block_layout : require
+
+// ----------------------------------------------------------------------------
+
+#include "../../interop.h"
+
+// ----------------------------------------------------------------------------
+
+layout(scalar, set = 0, binding = kDescriptorSetBinding_StorageBuffer_Position)
+buffer SBO_positions_ {
+  vec4 Positions[];
+};
+
+layout(push_constant, scalar)
+uniform PushConstant_ {
+  layout(offset = 64) PushConstant_Compute pushConstant;
+};
+
+// ----------------------------------------------------------------------------
+
+vec3 wave(in vec3 pt, float wavelength, float amplitude, float speed, in vec2 direction) {
+  direction = normalize(direction);
+
+  const float w = 2.0f / wavelength;
+  const float param = dot(pt.xz, direction) * w + speed * pushConstant.time;
+  const vec2 crest = direction * cos(param) * (1.0f / w);
+
+  return vec3(
+    crest.x,
+    amplitude * sin(param),
+    crest.y
+  );
+}
+
+// ----------------------------------------------------------------------------
+
+layout(local_size_x = kCompute_Simulation_kernelSize_x) in;
+
+void main() {
+  const uint gid = gl_GlobalInvocationID.x;
+
+  if (gid >= pushConstant.numElems) {
+    return;
+  }
+
+  // We fetch the original particle position on the back buffer, as we will
+  // update their xz position too (not just their height).
+  const vec4 particle = Positions[pushConstant.numElems + gid];
+  vec3 pos = particle.xyz;
+
+  // --------------------------------
+
+  float W = 2.5f;
+  float A = 0.20f;
+  float S = 2.0f;
+
+  pos = wave(pos, W, A, S, vec2(1.0, 0.0))
+      + wave(pos, W * 0.25f, A*0.5, S*1.1, vec2(1.0, -0.2))
+      + wave(pos, W * 0.125f, A*0.25, S*1.21, vec2(0.8, +0.5))
+      + wave(pos, W * 0.5f, A*0.75, S*0.9, vec2(0.8, 3.1))
+      ;
+  pos.xz = particle.xz + pos.xz / 4.0;
+
+  float size = 4.0f * (1.0 - smoothstep(-0.75, +0.75, pos.y));
+
+  // --------------------------------
+
+  Positions[gid] = vec4(pos, size);
+}
+
+// ----------------------------------------------------------------------------

--- a/src/samples/07_compute/shaders/glsl/sort/simulation.comp.glsl
+++ b/src/samples/07_compute/shaders/glsl/sort/simulation.comp.glsl
@@ -52,18 +52,18 @@ void main() {
 
   // --------------------------------
 
-  float W = 2.5f;
+  float W = 2.50f;
   float A = 0.20f;
-  float S = 2.0f;
+  float S = 2.10f;
 
   pos = wave(pos, W, A, S, vec2(1.0, 0.0))
-      + wave(pos, W * 0.25f, A*0.5, S*1.1, vec2(1.0, -0.2))
-      + wave(pos, W * 0.125f, A*0.25, S*1.21, vec2(0.8, +0.5))
-      + wave(pos, W * 0.5f, A*0.75, S*0.9, vec2(0.8, 3.1))
+      + wave(pos, W * 0.250f, A * 0.50f, S * 1.10f, vec2(1.0, -0.2))
+      + wave(pos, W * 0.125f, A * 0.25f, S * 1.21f, vec2(0.8, +0.5))
+      + wave(pos, W * 0.500f, A * 0.75f, S * 0.90f, vec2(0.8, +3.1))
       ;
-  pos.xz = particle.xz + pos.xz / 4.0;
+  pos.xz = particle.xz + pos.xz / 4.0f;
 
-  float size = 4.0f * (1.0 - smoothstep(-0.75, +0.75, pos.y));
+  float size = 5.0f * (1.0f - smoothstep(-0.65f, +0.65f, pos.y));
 
   // --------------------------------
 

--- a/src/samples/07_compute/shaders/glsl/sort/sort_indices.comp.glsl
+++ b/src/samples/07_compute/shaders/glsl/sort/sort_indices.comp.glsl
@@ -1,0 +1,74 @@
+#version 460
+#extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_scalar_block_layout : require
+
+//-----------------------------------------------------------------------------
+//
+//  This implement one step of a simple bitonic sort, where:
+//    * Input keys are float32 dot product values.
+//    * Output sorted values are uint32 indices.
+//
+//-----------------------------------------------------------------------------
+
+#include "../../interop.h"
+
+//-----------------------------------------------------------------------------
+
+layout(scalar, set = 0, binding = kDescriptorSetBinding_StorageBuffer_DotProduct)
+readonly buffer SBO_dot_products_ {
+  float Keys[];
+};
+
+layout(scalar, binding = kDescriptorSetBinding_StorageBuffer_Index)
+buffer SBO_indices_ {
+  uint Indices[];
+};
+
+layout(push_constant, scalar)
+uniform PushConstant_ {
+  layout(offset = 64) PushConstant_Compute pushConstant;
+};
+
+//-----------------------------------------------------------------------------
+
+void CompareAndSwap(in bool is_greater_than, inout uint left, inout uint right) {
+  if (is_greater_than == (Keys[left] > Keys[right])) {
+    left  ^= right;
+    right ^= left;
+    left  ^= right;
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+layout(local_size_x = kCompute_SortIndex_kernelSize_x) in;
+
+void main() {
+  const uint gid = gl_GlobalInvocationID.x;
+
+  if (gid >= pushConstant.numElems) {
+    return;
+  }
+
+  const uint read_offset = pushConstant.readOffset;
+  const uint write_offset = pushConstant.writeOffset;
+  const uint block_width = pushConstant.blockWidth;
+  const uint max_block_width = pushConstant.maxBlockWidth;
+
+  const uint pair_distance = block_width / 2u;
+
+  const uint block_offset = (gid / pair_distance) * block_width;
+  const uint left_id = block_offset + (gid % pair_distance);
+  const uint right_id = left_id + pair_distance;
+
+  uint left_data  = Indices[read_offset + left_id];
+  uint right_data = Indices[read_offset + right_id];
+
+  const bool order = bool((left_id / max_block_width) & 1u);
+  CompareAndSwap(order, left_data, right_data);
+
+  Indices[write_offset + left_id]  = left_data;
+  Indices[write_offset + right_id] = right_data;
+}
+
+//-----------------------------------------------------------------------------

--- a/src/samples/07_compute/shaders/interop.h
+++ b/src/samples/07_compute/shaders/interop.h
@@ -1,0 +1,75 @@
+#ifndef SHADERS_INTEROP_H_
+#define SHADERS_INTEROP_H_
+
+// ---------------------------------------------------------------------------
+
+#ifdef __cplusplus
+#define UINT uint32_t
+#else
+#define UINT uint
+#endif
+
+const UINT kAttribLocation_Position = 0;
+
+const UINT kDescriptorSetBinding_UniformBuffer = 0;
+const UINT kDescriptorSetBinding_StorageBuffer_Position = 1;
+const UINT kDescriptorSetBinding_StorageBuffer_Index = 2;
+const UINT kDescriptorSetBinding_StorageBuffer_DotProduct = 3;
+
+const UINT kCompute_Simulation_kernelSize_x = 256;
+const UINT kCompute_FillIndex_kernelSize_x = 256;
+const UINT kCompute_DotProduct_kernelSize_x = 256;
+const UINT kCompute_SortIndex_kernelSize_x = 256;
+
+#undef UINT
+
+const float kTwoPi = 6.28318530718f;
+
+// ---------------------------------------------------------------------------
+
+struct Camera {
+  mat4 viewMatrix;
+  mat4 projectionMatrix;
+};
+
+struct Model {
+  mat4 worldMatrix;
+};
+
+// ---------------------------------------------------------------------------
+
+struct Scene {
+  Camera camera;
+};
+
+// ---------------------------------------------------------------------------
+
+struct UniformData {
+  Scene scene;
+};
+
+struct PushConstant_Graphics {
+  Model model;
+};
+
+struct PushConstant_Compute {
+  Model model;
+  float time;
+  uint numElems;
+  uint padding_[2];
+  uint readOffset;
+  uint writeOffset;
+  uint blockWidth;
+  uint maxBlockWidth;
+};
+
+// ---------------------------------------------------------------------------
+
+struct PushConstant {
+  PushConstant_Graphics graphics;
+  PushConstant_Compute compute;
+};
+
+// ---------------------------------------------------------------------------
+
+#endif

--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -60,5 +60,6 @@ add_simple_demo(03_descriptor_set)
 add_simple_demo(04_texturing)
 add_simple_demo(05_stencil_op)
 add_simple_demo(06_blend_op)
+add_simple_demo(07_compute)
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Sample

Add a waves simulation sample that simulate, sort, and render a million (1024²) alpha blended particles.

##### Framework

* Add Compute pipeline support with buffer barrier,
* Add parameters to buffer creation / upload interface,
* Move part of RenderPassEncoder to GenericPassEncoder.
* Improve CMake build to track glsl root headers as dependencies.