### PR TITLE
Maintenance

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -127,6 +127,8 @@ Each Android sample provides a set of CMake debug targets in the form `{prefix}{
 
 _Device-dependent targets (**install**, **run**, **log**) require a compatible connected Android device._
 
+_**Note:** the Gradle's cmake cache directory (`.cxx` in projects subdirectory) might require to be cleaned up manually when local configurations change (eg. Vulkan SDK directory)._
+
 #### Assets
 
 A few assets are served via `git-lfs` but most will be downloaded automatically on CMake Cache generation time.

--- a/framework/src/aer/application.h
+++ b/framework/src/aer/application.h
@@ -54,7 +54,7 @@ class Application : public EventCallbacks
 
   virtual void draw(CommandEncoder const& cmd) {}
 
-  void drawUI(CommandEncoder const& cmd);
+  virtual void drawUI(CommandEncoder const& cmd);
 
  protected:
   [[nodiscard]]

--- a/framework/src/aer/core/logger.h
+++ b/framework/src/aer/core/logger.h
@@ -232,7 +232,7 @@ class Logger : public Singleton<Logger> {
 // Special aliases.
 
 #define LOG_FATAL(...)  LOGE(__VA_ARGS__); exit(-1)
-#define LOG_LINE()      LOGD("{} {}", __FUNCTION__, __LINE__)
+#define LOG_LINE()      LOGD("{} {}", __FILE__, __LINE__)
 #define LOG_CHECK(x)    assert(x)
 
 // ----------------------------------------------------------------------------

--- a/framework/src/aer/platform/vulkan/allocator.cc
+++ b/framework/src/aer/platform/vulkan/allocator.cc
@@ -93,7 +93,8 @@ backend::Buffer Allocator::createBuffer(
   }
 
   // Retrieve the buffer address.
-  if (usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) {
+  if (VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT == (usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT))
+  {
     auto const buffer_device_addr_info = VkBufferDeviceAddressInfoKHR{
       .sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_KHR,
       .buffer = buffer.buffer,

--- a/framework/src/aer/platform/vulkan/allocator.cc
+++ b/framework/src/aer/platform/vulkan/allocator.cc
@@ -39,10 +39,11 @@ void Allocator::release() {
 // ----------------------------------------------------------------------------
 
 backend::Buffer Allocator::createBuffer(
+  std::string const& name,
   VkDeviceSize size,
-  VkBufferUsageFlags2KHR usage,
-  VmaMemoryUsage memory_usage,
-  VmaAllocationCreateFlags flags
+  VkBufferUsageFlags2KHR const usage,
+  VmaMemoryUsage const memory_usage,
+  VmaAllocationCreateFlags const flags
 ) const {
   backend::Buffer buffer{};
 
@@ -64,7 +65,7 @@ backend::Buffer Allocator::createBuffer(
   auto buffer_create_info = VkBufferCreateInfo{
     .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
 #if 0
-    .pNext = &usage_flag2_info;
+    .pNext = &usage_flag2_info,
 #else
     .usage = static_cast<uint32_t>(usage),
 #endif
@@ -86,6 +87,20 @@ backend::Buffer Allocator::createBuffer(
     &buffer.allocation,
     &result_alloc_info
   ));
+
+  // Name the buffer for debugging.
+  if (!name.empty()) {
+    vk_utils::SetDebugObjectName(device_, buffer.buffer, name);
+  }
+
+  // Retrieve the buffer address.
+  if (usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) {
+    auto const buffer_device_addr_info = VkBufferDeviceAddressInfoKHR{
+      .sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_KHR,
+      .buffer = buffer.buffer,
+    };
+    buffer.address = vkGetBufferDeviceAddress(device_, &buffer_device_addr_info);
+  }
 
   return buffer;
 }

--- a/framework/src/aer/platform/vulkan/allocator.cc
+++ b/framework/src/aer/platform/vulkan/allocator.cc
@@ -54,24 +54,23 @@ backend::Buffer Allocator::createBuffer(
     }
   }
 
-  // auto const usage_flag2_info = VkBufferUsageFlags2CreateInfoKHR{
-  //   .sType = VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR,
-  //   .usage = usage
-  //          // | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT //
-  //           //VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT_KHR
-  //          ,
-  // };
-
   auto buffer_create_info = VkBufferCreateInfo{
     .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-#if 0
-    .pNext = &usage_flag2_info,
-#else
-    .usage = static_cast<uint32_t>(usage),
-#endif
+    .pNext = nullptr,
+    .size = size,
+    .usage = static_cast<VkBufferUsageFlags>(usage),
     .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
   };
-  buffer_create_info.size = size;
+
+#if 0
+  // [to use maintenance5]
+  auto const usage_flag2_info = VkBufferUsageFlags2CreateInfoKHR{
+    .sType = VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR,
+    .usage = usage,
+  };
+  buffer_create_info.pNext = &usage_flag2_info;
+  buffer_create_info.usage = VkBufferUsageFlags{0};
+#endif
 
   auto alloc_create_info = VmaAllocationCreateInfo{
     .flags = flags,

--- a/framework/src/aer/platform/vulkan/allocator.cc
+++ b/framework/src/aer/platform/vulkan/allocator.cc
@@ -53,25 +53,31 @@ backend::Buffer Allocator::createBuffer(
     }
   }
 
-  auto const usage_flag2_info = VkBufferUsageFlags2CreateInfoKHR{
-    .sType = VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR,
-    .usage = usage
-           | VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT_KHR //
-           ,
-  };
+  // auto const usage_flag2_info = VkBufferUsageFlags2CreateInfoKHR{
+  //   .sType = VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR,
+  //   .usage = usage
+  //          // | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT //
+  //           //VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT_KHR
+  //          ,
+  // };
 
-  // Create buffer.
-  auto const buffer_create_info = VkBufferCreateInfo{
+  auto buffer_create_info = VkBufferCreateInfo{
     .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
-    .pNext = &usage_flag2_info,
-    .size = size,
+#if 0
+    .pNext = &usage_flag2_info;
+#else
+    .usage = static_cast<uint32_t>(usage),
+#endif
     .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
   };
+  buffer_create_info.size = size;
+
   auto alloc_create_info = VmaAllocationCreateInfo{
     .flags = flags,
     .usage = memory_usage,
   };
   auto result_alloc_info = VmaAllocationInfo{};
+
   CHECK_VK(vmaCreateBuffer(
     handle_,
     &buffer_create_info,
@@ -80,13 +86,6 @@ backend::Buffer Allocator::createBuffer(
     &buffer.allocation,
     &result_alloc_info
   ));
-
-  // Get its GPU address.
-  VkBufferDeviceAddressInfoKHR const buffer_device_addr_info{
-    .sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_KHR,
-    .buffer = buffer.buffer,
-  };
-  buffer.address = vkGetBufferDeviceAddress(device_, &buffer_device_addr_info);
 
   return buffer;
 }

--- a/framework/src/aer/platform/vulkan/allocator.cc
+++ b/framework/src/aer/platform/vulkan/allocator.cc
@@ -104,7 +104,7 @@ backend::Buffer Allocator::createStagingBuffer(
   // Create buffer.
   backend::Buffer staging_buffer{createBuffer(
     static_cast<VkDeviceSize>(bytesize),
-    VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT_KHR,
+    VK_BUFFER_USAGE_TRANSFER_SRC_BIT, //
     VMA_MEMORY_USAGE_CPU_TO_GPU,
     VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT
   )};

--- a/framework/src/aer/platform/vulkan/allocator.h
+++ b/framework/src/aer/platform/vulkan/allocator.h
@@ -35,7 +35,9 @@ class Allocator {
   ) const;
 
   void destroyBuffer(backend::Buffer const& buffer) const {
-    vmaDestroyBuffer(handle_, buffer.buffer, buffer.allocation);
+    if (buffer.buffer != VK_NULL_HANDLE) {
+      vmaDestroyBuffer(handle_, buffer.buffer, buffer.allocation);
+    }
   }
 
   [[nodiscard]]

--- a/framework/src/aer/platform/vulkan/allocator.h
+++ b/framework/src/aer/platform/vulkan/allocator.h
@@ -28,11 +28,22 @@ class Allocator {
 
   [[nodiscard]]
   backend::Buffer createBuffer(
+    std::string const &name,
     VkDeviceSize const size,
     VkBufferUsageFlags2KHR const usage,   // !! require maintenance5 !!
     VmaMemoryUsage const memory_usage = VMA_MEMORY_USAGE_AUTO,
     VmaAllocationCreateFlags const flags = {}
   ) const;
+
+  [[nodiscard]]
+  backend::Buffer createBuffer(
+    VkDeviceSize const size,
+    VkBufferUsageFlags2KHR const usage,   // !! require maintenance5 !!
+    VmaMemoryUsage const memory_usage = VMA_MEMORY_USAGE_AUTO,
+    VmaAllocationCreateFlags const flags = {}
+  ) const {
+    return createBuffer("", size, usage, memory_usage, flags);
+  }
 
   void destroyBuffer(backend::Buffer const& buffer) const {
     if (buffer.buffer != VK_NULL_HANDLE) {

--- a/framework/src/aer/platform/vulkan/command_encoder.cc
+++ b/framework/src/aer/platform/vulkan/command_encoder.cc
@@ -346,7 +346,7 @@ backend::Buffer CommandEncoder::createBufferAndUpload(
 
   auto device_buffer{allocator_ptr_->createBuffer(
     static_cast<VkDeviceSize>(buffer_bytesize),
-    usage | VK_BUFFER_USAGE_2_TRANSFER_DST_BIT_KHR,
+    usage | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
     VMA_MEMORY_USAGE_GPU_ONLY
   )};
   transferBufferToDevice(

--- a/framework/src/aer/platform/vulkan/context.cc
+++ b/framework/src/aer/platform/vulkan/context.cc
@@ -100,6 +100,35 @@ VkSampleCountFlagBits Context::max_sample_count() const noexcept {
 
 // ----------------------------------------------------------------------------
 
+[[nodiscard]]
+backend::Buffer Context::createBuffer(
+  std::string const& name,
+  VkDeviceSize const size,
+  VkBufferUsageFlags2KHR const usage,
+  VmaMemoryUsage const memory_usage,
+  VmaAllocationCreateFlags const flags
+) const {
+  auto buffer = allocator_.createBuffer(size, usage, memory_usage, flags);
+
+  // Name the buffer for debugging.
+  if (!name.empty()) {
+    vk_utils::SetDebugObjectName(handle_, buffer.buffer, name);
+  }
+
+  // Retrieve the buffer address.
+  if (usage & VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT_KHR) {
+    auto const buffer_device_addr_info = VkBufferDeviceAddressInfoKHR{
+      .sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_KHR,
+      .buffer = buffer.buffer,
+    };
+    buffer.address = vkGetBufferDeviceAddress(handle_, &buffer_device_addr_info);
+  }
+
+  return buffer;
+}
+
+// ----------------------------------------------------------------------------
+
 backend::Image Context::createImage2D(
   uint32_t width,
   uint32_t height,

--- a/framework/src/aer/platform/vulkan/context.cc
+++ b/framework/src/aer/platform/vulkan/context.cc
@@ -683,12 +683,6 @@ bool Context::initDevice() {
     // Non core
 
     add_device_feature(
-      VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME,
-      feature_.descriptor_buffer_features,
-      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT
-    );
-
-    add_device_feature(
       VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME,
       feature_.extended_dynamic_state3,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT
@@ -711,6 +705,12 @@ bool Context::initDevice() {
       feature_.acceleration_structure,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR
     );
+
+    // add_device_feature(
+    //   VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME,
+    //   feature_.descriptor_buffer_features,
+    //   VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT
+    // );
 
 #if !defined(ANDROID)
     add_device_feature(

--- a/framework/src/aer/platform/vulkan/context.cc
+++ b/framework/src/aer/platform/vulkan/context.cc
@@ -729,16 +729,18 @@ bool Context::initDevice() {
     if (vulkan_xr_) {
       LOG_CHECK(features_.v11.multiview && "Multiview required (Vulkan 1.1 core)");
     }
-    LOG_CHECK(features_.v12.timelineSemaphore && "Timeline semaphore required (Vulkan 1.2 core)");
-    LOG_CHECK(features_.v12.bufferDeviceAddress && "Buffer device address required (Vulkan 1.2 core)");
 
+    // LOG_CHECK(features_.v12.shaderFloat16);
     LOG_CHECK(features_.v12.descriptorIndexing);
-    LOG_CHECK(features_.v12.runtimeDescriptorArray);
+    LOG_CHECK(features_.v12.shaderSampledImageArrayNonUniformIndexing);
+    LOG_CHECK(features_.v12.shaderStorageBufferArrayNonUniformIndexing);
     LOG_CHECK(features_.v12.descriptorBindingPartiallyBound);
     LOG_CHECK(features_.v12.descriptorBindingSampledImageUpdateAfterBind);
     LOG_CHECK(features_.v12.descriptorBindingStorageBufferUpdateAfterBind);
-    LOG_CHECK(features_.v12.shaderSampledImageArrayNonUniformIndexing);
-    LOG_CHECK(features_.v12.shaderStorageBufferArrayNonUniformIndexing);
+    LOG_CHECK(features_.v12.runtimeDescriptorArray);
+    LOG_CHECK(features_.v12.scalarBlockLayout);
+    LOG_CHECK(features_.v12.timelineSemaphore && "Timeline semaphore required (Vulkan 1.2 core)");
+    LOG_CHECK(features_.v12.bufferDeviceAddress && "Buffer device address required (Vulkan 1.2 core)");
 
     LOG_CHECK(features_.v13.synchronization2 && "Synchronization2 required (Vulkan 1.3 core)");
     LOG_CHECK(features_.v13.dynamicRendering && "Dynamic Rendering required (Vulkan 1.3 core)");
@@ -808,25 +810,20 @@ bool Context::initDevice() {
 
       // When secondary queue are not found, use the main one instead.
       // (could have issue if used concurrently)
-      if (!queue_found) {
-        if (j > 0) {
-          pair.first->family_index = queues[0].first->family_index;
-          pair.first->queue_index = queues[0].first->queue_index;
-        }
+      if (!queue_found && (j > 0)) {
+        pair.first->family_index = queues[0].first->family_index;
+        pair.first->queue_index = queues[0].first->queue_index;
       }
 
       if (UINT32_MAX == pair.first->family_index) {
-        LOGE(
-          "Could not find a queue family with the requested support {:08x}.",
-          pair.second
-        );
+        LOGE("Could not find a queue family with the requested support {:08x}.", pair.second);
         return false;
       }
     }
 
-    for (uint32_t i = 0u; i < queue_family_count; ++i) {
-      if (queue_infos[i].queueCount > 0u) {
-        queue_create_infos.push_back(queue_infos[i]);
+    for (auto const& queue_info : queue_infos) {
+      if (queue_info.queueCount > 0u) {
+        queue_create_infos.push_back(queue_info);
       }
     }
   }

--- a/framework/src/aer/platform/vulkan/context.cc
+++ b/framework/src/aer/platform/vulkan/context.cc
@@ -100,35 +100,6 @@ VkSampleCountFlagBits Context::max_sample_count() const noexcept {
 
 // ----------------------------------------------------------------------------
 
-[[nodiscard]]
-backend::Buffer Context::createBuffer(
-  std::string const& name,
-  VkDeviceSize const size,
-  VkBufferUsageFlags2KHR const usage,
-  VmaMemoryUsage const memory_usage,
-  VmaAllocationCreateFlags const flags
-) const {
-  auto buffer = allocator_.createBuffer(size, usage, memory_usage, flags);
-
-  // Name the buffer for debugging.
-  if (!name.empty()) {
-    vk_utils::SetDebugObjectName(handle_, buffer.buffer, name);
-  }
-
-  // Retrieve the buffer address.
-  if (usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) {
-    auto const buffer_device_addr_info = VkBufferDeviceAddressInfoKHR{
-      .sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_KHR,
-      .buffer = buffer.buffer,
-    };
-    buffer.address = vkGetBufferDeviceAddress(handle_, &buffer_device_addr_info);
-  }
-
-  return buffer;
-}
-
-// ----------------------------------------------------------------------------
-
 backend::Image Context::createImage2D(
   uint32_t width,
   uint32_t height,

--- a/framework/src/aer/platform/vulkan/context.cc
+++ b/framework/src/aer/platform/vulkan/context.cc
@@ -360,7 +360,7 @@ void Context::finishTransientCommandEncoder(
 
   CHECK_VK( vkQueueSubmit2(queue(target_queue).queue, 1u, &submit_info_2, fence) );
 
-  CHECK_VK( vkWaitForFences(handle_, 1u, &fence, VK_TRUE, UINT64_MAX) );
+  CHECK_VK( vkWaitForFences(handle_, 1u, &fence, VK_TRUE, 2000000000ULL) ); // UINT64_MAX
   vkDestroyFence(handle_, fence, nullptr);
 
   VkCommandBuffer command_buffers[] = { encoder.handle() };

--- a/framework/src/aer/platform/vulkan/context.cc
+++ b/framework/src/aer/platform/vulkan/context.cc
@@ -664,19 +664,19 @@ bool Context::initDevice() {
 
     add_device_feature(
       VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME,
-      feature_.index_type_uint8,
+      features_.index_type_uint8,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT
     );
 
     add_device_feature(
       VK_KHR_MAINTENANCE_5_EXTENSION_NAME,
-      feature_.maintenance5,
+      features_.maintenance5,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR
     );
 
     add_device_feature(
       VK_KHR_MAINTENANCE_6_EXTENSION_NAME,
-      feature_.maintenance6,
+      features_.maintenance6,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR
     );
 
@@ -684,65 +684,65 @@ bool Context::initDevice() {
 
     add_device_feature(
       VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME,
-      feature_.extended_dynamic_state3,
+      features_.extended_dynamic_state3,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT
     );
 
     add_device_feature(
       VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME,
-      feature_.vertex_input_dynamic_state,
+      features_.vertex_input_dynamic_state,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT
     );
 
     add_device_feature(
       VK_EXT_IMAGE_VIEW_MIN_LOD_EXTENSION_NAME,
-      feature_.image_view_min_lod,
+      features_.image_view_min_lod,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_MIN_LOD_FEATURES_EXT
     );
 
     add_device_feature(
       VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
-      feature_.acceleration_structure,
+      features_.acceleration_structure,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR
     );
 
     // add_device_feature(
     //   VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME,
-    //   feature_.descriptor_buffer_features,
+    //   features_.descriptor_buffer_features,
     //   VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT
     // );
 
 #if !defined(ANDROID)
     add_device_feature(
       VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME,
-      feature_.ray_tracing_pipeline,
+      features_.ray_tracing_pipeline,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR
     );
 #endif
 
-    vk_utils::PushNextVKStruct(&feature_.base, &feature_.v11);
-    vk_utils::PushNextVKStruct(&feature_.base, &feature_.v12);
-    vk_utils::PushNextVKStruct(&feature_.base, &feature_.v13);
-    vkGetPhysicalDeviceFeatures2(gpu_, &feature_.base);
+    vk_utils::PushNextVKStruct(&features_.base, &features_.v11);
+    vk_utils::PushNextVKStruct(&features_.base, &features_.v12);
+    vk_utils::PushNextVKStruct(&features_.base, &features_.v13);
+    vkGetPhysicalDeviceFeatures2(gpu_, &features_.base);
 
     /* Check features. */
     if (vulkan_xr_) {
-      LOG_CHECK(feature_.v11.multiview && "Multiview required (Vulkan 1.1 core)");
+      LOG_CHECK(features_.v11.multiview && "Multiview required (Vulkan 1.1 core)");
     }
-    LOG_CHECK(feature_.v12.timelineSemaphore && "Timeline semaphore required (Vulkan 1.2 core)");
-    LOG_CHECK(feature_.v12.bufferDeviceAddress && "Buffer device address required (Vulkan 1.2 core)");
+    LOG_CHECK(features_.v12.timelineSemaphore && "Timeline semaphore required (Vulkan 1.2 core)");
+    LOG_CHECK(features_.v12.bufferDeviceAddress && "Buffer device address required (Vulkan 1.2 core)");
 
-    LOG_CHECK(feature_.v12.descriptorIndexing);
-    LOG_CHECK(feature_.v12.runtimeDescriptorArray);
-    LOG_CHECK(feature_.v12.descriptorBindingPartiallyBound);
-    LOG_CHECK(feature_.v12.descriptorBindingSampledImageUpdateAfterBind);
-    LOG_CHECK(feature_.v12.descriptorBindingStorageBufferUpdateAfterBind);
-    LOG_CHECK(feature_.v12.shaderSampledImageArrayNonUniformIndexing);
-    LOG_CHECK(feature_.v12.shaderStorageBufferArrayNonUniformIndexing);
+    LOG_CHECK(features_.v12.descriptorIndexing);
+    LOG_CHECK(features_.v12.runtimeDescriptorArray);
+    LOG_CHECK(features_.v12.descriptorBindingPartiallyBound);
+    LOG_CHECK(features_.v12.descriptorBindingSampledImageUpdateAfterBind);
+    LOG_CHECK(features_.v12.descriptorBindingStorageBufferUpdateAfterBind);
+    LOG_CHECK(features_.v12.shaderSampledImageArrayNonUniformIndexing);
+    LOG_CHECK(features_.v12.shaderStorageBufferArrayNonUniformIndexing);
 
-    LOG_CHECK(feature_.v13.synchronization2 && "Synchronization2 required (Vulkan 1.3 core)");
-    LOG_CHECK(feature_.v13.dynamicRendering && "Dynamic Rendering required (Vulkan 1.3 core)");
-    LOG_CHECK(feature_.v13.maintenance4 && "Maintenance4 required (Vulkan 1.3 core)");
+    LOG_CHECK(features_.v13.synchronization2 && "Synchronization2 required (Vulkan 1.3 core)");
+    LOG_CHECK(features_.v13.dynamicRendering && "Dynamic Rendering required (Vulkan 1.3 core)");
+    LOG_CHECK(features_.v13.maintenance4 && "Maintenance4 required (Vulkan 1.3 core)");
   }
 
 
@@ -843,7 +843,7 @@ bool Context::initDevice() {
 
     VkDeviceCreateInfo const device_info{
       .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
-      .pNext = &feature_.base,
+      .pNext = &features_.base,
       .queueCreateInfoCount = static_cast<uint32_t>(queue_create_infos.size()),
       .pQueueCreateInfos = queue_create_infos.data(),
       .enabledExtensionCount = static_cast<uint32_t>(extension_names.size()),

--- a/framework/src/aer/platform/vulkan/context.cc
+++ b/framework/src/aer/platform/vulkan/context.cc
@@ -116,7 +116,7 @@ backend::Buffer Context::createBuffer(
   }
 
   // Retrieve the buffer address.
-  if (usage & VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT_KHR) {
+  if (usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) {
     auto const buffer_device_addr_info = VkBufferDeviceAddressInfoKHR{
       .sType = VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO_KHR,
       .buffer = buffer.buffer,

--- a/framework/src/aer/platform/vulkan/context.h
+++ b/framework/src/aer/platform/vulkan/context.h
@@ -109,12 +109,21 @@ class Context {
 
   [[nodiscard]]
   backend::Buffer createBuffer(
+    std::string const& name,
+    VkDeviceSize const size,
+    VkBufferUsageFlags2KHR const usage,
+    VmaMemoryUsage const memory_usage = VMA_MEMORY_USAGE_AUTO,
+    VmaAllocationCreateFlags const flags = {}
+  ) const;
+
+  [[nodiscard]]
+  backend::Buffer createBuffer(
     VkDeviceSize const size,
     VkBufferUsageFlags2KHR const usage,
     VmaMemoryUsage const memory_usage = VMA_MEMORY_USAGE_AUTO,
     VmaAllocationCreateFlags const flags = {}
   ) const {
-    return allocator_.createBuffer(size, usage, memory_usage, flags);
+    return createBuffer("", size, usage, memory_usage, flags);
   }
 
   void destroyBuffer(backend::Buffer const& buffer) const {

--- a/framework/src/aer/platform/vulkan/context.h
+++ b/framework/src/aer/platform/vulkan/context.h
@@ -22,7 +22,7 @@ class Context {
     kCount,
   };
 
-  struct VulkanContextFeature {
+  struct VulkanContextFeatures {
     VkPhysicalDeviceFeatures2 base{.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
     VkPhysicalDeviceVulkan11Features v11{.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES};
     VkPhysicalDeviceVulkan12Features v12{.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES};
@@ -92,8 +92,8 @@ class Context {
   }
 
   [[nodiscard]]
-  VulkanContextFeature const& get_feature() const {
-    return feature_;
+  VulkanContextFeatures const& get_features() const {
+    return features_;
   }
 
   [[nodiscard]]
@@ -406,7 +406,7 @@ class Context {
       return false;
     }
     feature = { .sType = sType };
-    vk_utils::PushNextVKStruct(&feature_.base, &feature);
+    vk_utils::PushNextVKStruct(&features_.base, &feature);
     if (!dependencies.empty()) {
       device_extension_names_.insert(
         dependencies.cbegin(),
@@ -449,7 +449,7 @@ class Context {
     VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME,
   };
 
-  VulkanContextFeature feature_{};
+  VulkanContextFeatures features_{};
 
   VkInstance instance_{};
   VkPhysicalDevice gpu_{};

--- a/framework/src/aer/platform/vulkan/context.h
+++ b/framework/src/aer/platform/vulkan/context.h
@@ -307,7 +307,6 @@ class Context {
 
   // --- Transient Command Encoder Wrappers ---
 
-  // (formerly 'createBufferAndUpload')
   [[nodiscard]]
   backend::Buffer transientCreateBuffer(
     void const* host_data,

--- a/framework/src/aer/platform/vulkan/context.h
+++ b/framework/src/aer/platform/vulkan/context.h
@@ -114,7 +114,9 @@ class Context {
     VkBufferUsageFlags2KHR const usage,
     VmaMemoryUsage const memory_usage = VMA_MEMORY_USAGE_AUTO,
     VmaAllocationCreateFlags const flags = {}
-  ) const;
+  ) const {
+    return allocator_.createBuffer(name, size, usage, memory_usage, flags);
+  }
 
   [[nodiscard]]
   backend::Buffer createBuffer(

--- a/framework/src/aer/platform/vulkan/context.h
+++ b/framework/src/aer/platform/vulkan/context.h
@@ -34,12 +34,12 @@ class Context {
     VkPhysicalDeviceMaintenance6FeaturesKHR maintenance6{};                           // (!Quest3)
 
     // (Non Core)
-    VkPhysicalDeviceDescriptorBufferFeaturesEXT descriptor_buffer_features{};         // (!Quest3)
     VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3{};       // (!Quest3)
     VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT vertex_input_dynamic_state{};
     VkPhysicalDeviceImageViewMinLodFeaturesEXT image_view_min_lod{};
     VkPhysicalDeviceAccelerationStructureFeaturesKHR acceleration_structure{};
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_pipeline{};
+    // VkPhysicalDeviceDescriptorBufferFeaturesEXT descriptor_buffer_features{};         // (!Quest3)
   };
 
  public:

--- a/framework/src/aer/renderer/descriptor_registry.cc
+++ b/framework/src/aer/renderer/descriptor_registry.cc
@@ -248,7 +248,7 @@ void DescriptorRegistry::updateSceneIBL(Skybox const& skybox) const {
 // ----------------------------------------------------------------------------
 
 void DescriptorRegistry::initDescriptorPool(uint32_t const max_sets) {
-  auto const& context_feature = context_ptr_->get_feature();
+  auto const& context_feature = context_ptr_->get_features();
 
   /* Default pool, to adjust based on application needs. */
   descriptor_pool_sizes_ = {
@@ -292,7 +292,7 @@ void DescriptorRegistry::initDescriptorPool(uint32_t const max_sets) {
 // ----------------------------------------------------------------------------
 
 void DescriptorRegistry::setupMainDescriptors() {
-  auto const& context_feature = context_ptr_->get_feature();
+  auto const& context_feature = context_ptr_->get_features();
 
   createMainDescriptorSet(
     Type::Scene,

--- a/framework/src/aer/renderer/descriptor_registry.cc
+++ b/framework/src/aer/renderer/descriptor_registry.cc
@@ -114,37 +114,37 @@ VkDescriptorSet DescriptorRegistry::allocateDescriptorSet(
 
 // ----------------------------------------------------------------------------
 
-backend::Buffer DescriptorRegistry::allocateDescriptorBuffer(
-  VkDescriptorSetLayout const layout,
-  VkDeviceSize *pLayoutSize,
-  VkDeviceSize *pOffset,
-  uint32_t num_elems,
-  VkBufferUsageFlags2KHR usage_flags,
-  std::string const& name
-) const {
-  LOG_CHECK(vkGetDescriptorSetLayoutSizeEXT);
-  vkGetDescriptorSetLayoutSizeEXT(device_, layout, pLayoutSize);
+// backend::Buffer DescriptorRegistry::allocateDescriptorBuffer(
+//   VkDescriptorSetLayout const layout,
+//   VkDeviceSize *pLayoutSize,
+//   VkDeviceSize *pOffset,
+//   uint32_t num_elems,
+//   VkBufferUsageFlags2KHR usage_flags,
+//   std::string const& name
+// ) const {
+//   LOG_CHECK(vkGetDescriptorSetLayoutSizeEXT);
+//   vkGetDescriptorSetLayoutSizeEXT(device_, layout, pLayoutSize);
 
-  auto const desc_buffer_props = context_ptr_->descriptor_buffer_properties();
-  *pLayoutSize = utils::AlignTo(*pLayoutSize, desc_buffer_props.descriptorBufferOffsetAlignment);
+//   auto const desc_buffer_props = context_ptr_->descriptor_buffer_properties();
+//   *pLayoutSize = utils::AlignTo(*pLayoutSize, desc_buffer_props.descriptorBufferOffsetAlignment);
 
-  LOG_CHECK(vkGetDescriptorSetLayoutBindingOffsetEXT);
-  vkGetDescriptorSetLayoutBindingOffsetEXT(device_, layout, 0u, pOffset);
+//   LOG_CHECK(vkGetDescriptorSetLayoutBindingOffsetEXT);
+//   vkGetDescriptorSetLayoutBindingOffsetEXT(device_, layout, 0u, pOffset);
 
-  auto buffer = context_ptr_->createBuffer(
-    *pLayoutSize * num_elems,
-      VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT
-    | usage_flags
-    ,
-    VMA_MEMORY_USAGE_CPU_TO_GPU
-  );
+//   auto buffer = context_ptr_->createBuffer(
+//     *pLayoutSize * num_elems,
+//       VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT
+//     | usage_flags
+//     ,
+//     VMA_MEMORY_USAGE_CPU_TO_GPU
+//   );
 
-  if (!name.empty()) {
-    vk_utils::SetDebugObjectName(device_, buffer.buffer, "DescriptorRegistry::DescriptorSet::" + name);
-  }
+//   if (!name.empty()) {
+//     vk_utils::SetDebugObjectName(device_, buffer.buffer, "DescriptorRegistry::DescriptorSet::" + name);
+//   }
 
-  return buffer;
-}
+//   return buffer;
+// }
 
 // ----------------------------------------------------------------------------
 
@@ -371,8 +371,8 @@ DescriptorRegistry::Descriptor& DescriptorRegistry::_intializeMainDescriptor(
     .layout = createLayout(layout_params, layout_flags, name),
     .set = {},
     .dynamicOffsets = {},
-    .layoutSize = 0u,
-    .offset = 0u,
+    // .layoutSize = 0u,
+    // .offset = 0u,
   };
 
   switch (type) {
@@ -410,26 +410,26 @@ void DescriptorRegistry::createMainDescriptorSet(
 
 // ----------------------------------------------------------------------------
 
-void DescriptorRegistry::createMainDescriptorBuffer(
-  Type const type,
-  DescriptorSetLayoutParamsBuffer const& layout_params,
-  VkDescriptorSetLayoutCreateFlags layout_flags,
-  uint32_t num_elems,
-  VkBufferUsageFlags2KHR usage_flags,
-  std::string const& name
-) {
-  layout_flags |= VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+// void DescriptorRegistry::createMainDescriptorBuffer(
+//   Type const type,
+//   DescriptorSetLayoutParamsBuffer const& layout_params,
+//   VkDescriptorSetLayoutCreateFlags layout_flags,
+//   uint32_t num_elems,
+//   VkBufferUsageFlags2KHR usage_flags,
+//   std::string const& name
+// ) {
+//   layout_flags |= VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
 
-  auto &descriptor = _intializeMainDescriptor(type, layout_params, layout_flags, name);
+//   auto &descriptor = _intializeMainDescriptor(type, layout_params, layout_flags, name);
 
-  descriptor.buffer = allocateDescriptorBuffer(
-    descriptor.layout,
-    &descriptor.layoutSize,
-    &descriptor.offset,
-    num_elems,
-    usage_flags, // eg. VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT
-    name
-  );
-};
+//   descriptor.buffer = allocateDescriptorBuffer(
+//     descriptor.layout,
+//     &descriptor.layoutSize,
+//     &descriptor.offset,
+//     num_elems,
+//     usage_flags, // eg. VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT
+//     name
+//   );
+// };
 
 /* -------------------------------------------------------------------------- */

--- a/framework/src/aer/renderer/descriptor_registry.cc
+++ b/framework/src/aer/renderer/descriptor_registry.cc
@@ -75,7 +75,7 @@ VkDescriptorSetLayout DescriptorRegistry::createLayout(
     device_, &layout_create_info, nullptr, &descriptor_set_layout
   ));
   if (!name.empty()) {
-    vk_utils::SetDebugObjectName(device_, descriptor_set_layout, "DescriptorRegistry::DescriptorSetLayout::" + name);
+    context_ptr_->setDebugObjectName(descriptor_set_layout, "DescriptorRegistry::DescriptorSetLayout::" + name);
   }
 
   return descriptor_set_layout;
@@ -106,7 +106,7 @@ VkDescriptorSet DescriptorRegistry::allocateDescriptorSet(
   CHECK_VK(vkAllocateDescriptorSets(device_, &alloc_info, &descriptor_set));
 
   if (!name.empty()) {
-    vk_utils::SetDebugObjectName(device_, descriptor_set, "DescriptorRegistry::DescriptorSet::" + name);
+    context_ptr_->setDebugObjectName(descriptor_set, "DescriptorRegistry::DescriptorSet::" + name);
   }
 
   return descriptor_set;
@@ -140,7 +140,7 @@ VkDescriptorSet DescriptorRegistry::allocateDescriptorSet(
 //   );
 
 //   if (!name.empty()) {
-//     vk_utils::SetDebugObjectName(device_, buffer.buffer, "DescriptorRegistry::DescriptorSet::" + name);
+//     context_ptr_->setDebugObjectName(buffer.buffer, "DescriptorRegistry::DescriptorSet::" + name);
 //   }
 
 //   return buffer;
@@ -286,7 +286,7 @@ void DescriptorRegistry::initDescriptorPool(uint32_t const max_sets) {
     nullptr, &
     main_pool_
   ));
-  vk_utils::SetDebugObjectName(device_, main_pool_, "DescriptorRegistry::MainPool");
+  context_ptr_->setDebugObjectName(main_pool_, "DescriptorRegistry::MainPool");
 }
 
 // ----------------------------------------------------------------------------

--- a/framework/src/aer/renderer/descriptor_registry.h
+++ b/framework/src/aer/renderer/descriptor_registry.h
@@ -35,10 +35,10 @@ class DescriptorRegistry {
     VkDescriptorSet set{};
     mutable std::vector<uint32_t> dynamicOffsets{};
     // -----
-    // (descriptor buffer resources)
-    VkDeviceSize layoutSize{};
-    VkDeviceSize offset{};
-    backend::Buffer buffer{};
+    // // (descriptor buffer resources)
+    // VkDeviceSize layoutSize{};
+    // VkDeviceSize offset{};
+    // backend::Buffer buffer{};
   };
 
  public:
@@ -71,15 +71,15 @@ class DescriptorRegistry {
     std::string const& name = ""
   ) const;
 
-  [[nodiscard]]
-  backend::Buffer allocateDescriptorBuffer(
-    VkDescriptorSetLayout const layout,
-    VkDeviceSize *pLayoutSize,
-    VkDeviceSize *pOffset,
-    uint32_t num_elems,
-    VkBufferUsageFlags2KHR usage_flags,
-    std::string const& name = ""
-  ) const;
+  // [[nodiscard]]
+  // backend::Buffer allocateDescriptorBuffer(
+  //   VkDescriptorSetLayout const layout,
+  //   VkDeviceSize *pLayoutSize,
+  //   VkDeviceSize *pOffset,
+  //   uint32_t num_elems,
+  //   VkBufferUsageFlags2KHR usage_flags,
+  //   std::string const& name = ""
+  // ) const;
 
   void bindDescriptorSet(
     Type type,
@@ -116,14 +116,14 @@ class DescriptorRegistry {
     std::string const& name
   );
 
-  void createMainDescriptorBuffer(
-    Type const type,
-    DescriptorSetLayoutParamsBuffer const& layout_params,
-    VkDescriptorSetLayoutCreateFlags layout_flags,
-    uint32_t num_elems,
-    VkBufferUsageFlags2KHR usage_flags,
-    std::string const& name
-  );
+  // void createMainDescriptorBuffer(
+  //   Type const type,
+  //   DescriptorSetLayoutParamsBuffer const& layout_params,
+  //   VkDescriptorSetLayoutCreateFlags layout_flags,
+  //   uint32_t num_elems,
+  //   VkBufferUsageFlags2KHR usage_flags,
+  //   std::string const& name
+  // );
 
  private:
   Context const* context_ptr_{};

--- a/framework/src/aer/renderer/fx/envmap.cc
+++ b/framework/src/aer/renderer/fx/envmap.cc
@@ -70,7 +70,7 @@ void Envmap::init(RenderContext const& context) {
 
   /* Shared descriptor sets */
   {
-    VkDescriptorBindingFlags const kDefaultDescBindingFlags{
+    auto const kDefaultDescBindingFlags = VkDescriptorBindingFlags{
         VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT
       | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT
       | VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT
@@ -197,6 +197,11 @@ void Envmap::release() {
 // ----------------------------------------------------------------------------
 
 bool Envmap::setup(std::string_view hdr_filename) {
+  if (!context_ptr_) {
+    LOGW("Envmap not initialized.");
+    return false;
+  }
+
   if (!loadDiffuseEnvmap(hdr_filename)) {
     LOGE("Fail to load spherical map \"{}\".", hdr_filename);
     return false;

--- a/framework/src/aer/renderer/fx/envmap.cc
+++ b/framework/src/aer/renderer/fx/envmap.cc
@@ -9,10 +9,12 @@ void Envmap::init(RenderContext const& context) {
   context_ptr_ = &context;
 
   irradiance_matrices_buffer_ = context.createBuffer(
+    "Envmap::Buffer::IrradianceMatrices",
     sizeof(shader_interop::envmap::SHMatrices),
-      VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT
-    | VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT
-    | VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT_KHR
+      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
+    | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
+    | VK_BUFFER_USAGE_TRANSFER_SRC_BIT
+    | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT
   );
 
   /* Create the HDR envmaps & the BRDF LUT. */
@@ -300,9 +302,11 @@ void Envmap::computeIrradianceSHCoeff() {
   auto const& diffuse = images_[ImageType::Diffuse];
 
   backend::Buffer sh_coefficient_buffer{context_ptr_->createBuffer(
+    "Envmap::Buffer::SHCoefficient",
     bufferSize * sizeof(shader_interop::envmap::SHCoeff),
-      VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT
-    | VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT_KHR
+      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
+    | VK_BUFFER_USAGE_TRANSFER_SRC_BIT
+    | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT
   )};
 
   context_ptr_->updateDescriptorSet(descriptor_set_, {

--- a/framework/src/aer/renderer/fx/postprocess/compute/impl/depth_minmax.h
+++ b/framework/src/aer/renderer/fx/postprocess/compute/impl/depth_minmax.h
@@ -17,8 +17,8 @@ class DepthMinMax final : public ComputeFx {
     // (malformed, should use internal method to update descriptor..)
     buffers_.push_back(context_ptr_->createBuffer(
       2u * sizeof(float),
-        VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT
-      | VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT_KHR
+        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
+      | VK_BUFFER_USAGE_TRANSFER_SRC_BIT
     ));
 
     return true;

--- a/framework/src/aer/renderer/fx/skybox.cc
+++ b/framework/src/aer/renderer/fx/skybox.cc
@@ -148,10 +148,22 @@ void Skybox::release(RenderContext const& context) {
 // ----------------------------------------------------------------------------
 
 bool Skybox::setup(std::string_view hdr_filename) {
+  if (!context_ptr_) {
+    LOGW("Skybox not initialized.");
+    return false;
+  }
+
+  if (!context_ptr_->get_features().maintenance5.maintenance5) {
+    LOGW("Skybox IBLs requires the maintenance5 device extension.");
+    return false;
+  }
+
   setuped_ = envmap_.setup(hdr_filename);
+
   if (setuped_) {
     context_ptr_->descriptor_registry().updateSceneIBL(*this);
   }
+
   return setuped_;
 }
 

--- a/framework/src/aer/renderer/fx/skybox.cc
+++ b/framework/src/aer/renderer/fx/skybox.cc
@@ -43,11 +43,11 @@ void Skybox::init(RenderContext& context) {
 
     vertex_buffer_ = cmd.createBufferAndUpload(
       cube_.vertices(),
-      VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT
+      VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
     );
     index_buffer_ = cmd.createBufferAndUpload(
       cube_.indices(),
-      VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT
+      VK_BUFFER_USAGE_INDEX_BUFFER_BIT
     );
 
     context.finishTransientCommandEncoder(cmd);

--- a/framework/src/aer/renderer/gpu_resources.cc
+++ b/framework/src/aer/renderer/gpu_resources.cc
@@ -367,8 +367,8 @@ void GPUResources::uploadBuffers() {
   /* Allocate device buffers for meshes & their transforms. */
   vertex_buffer = context_.createBuffer(
     vertex_buffer_size,
-      VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT
-    | VK_BUFFER_USAGE_2_TRANSFER_DST_BIT_KHR
+      VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
+    | VK_BUFFER_USAGE_TRANSFER_DST_BIT
     | extra_flags
     ,
     VMA_MEMORY_USAGE_GPU_ONLY
@@ -377,8 +377,8 @@ void GPUResources::uploadBuffers() {
   if (index_buffer_size > 0) {
     index_buffer = context_.createBuffer(
       index_buffer_size,
-        VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT
-      | VK_BUFFER_USAGE_2_TRANSFER_DST_BIT_KHR
+        VK_BUFFER_USAGE_INDEX_BUFFER_BIT
+      | VK_BUFFER_USAGE_TRANSFER_DST_BIT
       | extra_flags
       ,
       VMA_MEMORY_USAGE_GPU_ONLY

--- a/framework/src/aer/renderer/raytracing_scene.cc
+++ b/framework/src/aer/renderer/raytracing_scene.cc
@@ -179,6 +179,7 @@ bool RayTracingScene::buildBLAS(scene::Mesh::SubMesh const& submesh) {
   );
 
   blas.buffer = context_ptr_->createBuffer(
+    "RayTracingScene::Buffer::BLAS",
     blas.build_sizes_info.accelerationStructureSize,
       VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR
     | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT
@@ -222,6 +223,7 @@ void RayTracingScene::buildTLAS() {
   );
 #else
   auto instances_buffer = context_ptr_->createBuffer(
+    "RayTracingScene::Buffer::Instances",
     tlas_.instances.size() * sizeof(tlas_.instances[0]),
       VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR
     | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT
@@ -265,8 +267,11 @@ void RayTracingScene::buildTLAS() {
   );
 
   tlas_.buffer = context_ptr_->createBuffer(
+    "RayTracingScene::Buffer::TLAS",
     tlas_.build_sizes_info.accelerationStructureSize,
-    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
+      VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR
+    | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT
+    ,
     VMA_MEMORY_USAGE_GPU_ONLY
   );
 
@@ -326,6 +331,7 @@ void RayTracingScene::buildAccelerationStructure(
   VkAccelerationStructureBuildRangeInfoKHR buildRangeInfo
 ) {
   scratch_buffer_ = context_ptr_->createBuffer(
+    "RayTracingScene::Buffer::Scratch",
     as->build_sizes_info.buildScratchSize,
       VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
     | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,

--- a/framework/src/aer/renderer/raytracing_scene.cc
+++ b/framework/src/aer/renderer/raytracing_scene.cc
@@ -319,8 +319,10 @@ void RayTracingScene::buildInstancesDataBuffer(
   }
   instances_data_buffer_ = context_ptr_->transientCreateBuffer(
     instances,
-    VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
+      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
+    | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT
   );
+  context_ptr_->setDebugObjectName(instances_data_buffer_.buffer, "RayTracingScene::Buffer::InstanceData");
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/android/aloha/src/cpp/main.cc
+++ b/samples/android/aloha/src/cpp/main.cc
@@ -48,7 +48,7 @@ private:
     renderer_.set_clear_color(vec4(0.75f, 0.15f, 0.30f, 1.0f));
 
     vertex_buffer_ = context_.transientCreateBuffer(
-      kVertices, VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT
+      kVertices, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
     );
 
     auto const shaders{context_.createShaderModules(COMPILED_SHADERS_DIR, {

--- a/samples/android/aloha_xr/src/AndroidManifest.xml
+++ b/samples/android/aloha_xr/src/AndroidManifest.xml
@@ -3,24 +3,21 @@
           xmlns:android="http://schemas.android.com/apk/res/android"
     tools:ignore="ExtraText">
 
-  <!-- Tell the system this app works in either 3dof or 6dof mode -->
-  <uses-feature
-    android:name="android.hardware.vr.headtracking"
-    android:required="false"
-    android:version="1"
-    />
+  <!-- Tell the system this app targets vulkan 1.3 -->
+  <uses-feature android:name="android.hardware.vulkan.version" android:version="0x403000" android:required="true" />
+  <!-- Tell the system to target advanced hardware support -->
+  <uses-feature android:name="android.hardware.vulkan.level" android:version="1" android:required="true" />
 
-  <uses-feature
-      android:name="com.oculus.experimental.enabled"
-      android:required="true"
-      />
+  <!-- Use experimental Meta XR SDK features -->
+  <!-- <uses-feature android:name="com.oculus.experimental.enabled" android:required="true" /> -->
+
+  <!-- Tell the system this app works in either 3dof or 6dof mode -->
+  <uses-feature android:name="android.hardware.vr.headtracking" android:required="false" android:version="1" />
+
 
   <!-- Tell the system this app can handle tracked remotes and hands -->
   <uses-permission android:name="com.oculus.permission.HAND_TRACKING" />
-  <uses-feature
-      android:name="oculus.software.handtracking"
-      android:required="false"
-      />
+  <uses-feature android:name="oculus.software.handtracking" android:required="false" />
 
   <!-- Recommended for haptic feedback -->
   <uses-permission android:name="android.permission.VIBRATE" />

--- a/samples/android/aloha_xr/src/cpp/main.cc
+++ b/samples/android/aloha_xr/src/cpp/main.cc
@@ -44,12 +44,12 @@ class SampleApp final : public Application {
 
     vertex_buffer_ = context_.transientCreateBuffer(
       kVertices,
-      VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT
+      VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
     );
 
     uniform_buffer_ = context_.createBuffer(
       2u * sizeof(shader_interop::UniformCameraData),
-      VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT,
+      VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
       VMA_MEMORY_USAGE_CPU_TO_GPU
     );
 

--- a/samples/desktop/00_hello/main.cc
+++ b/samples/desktop/00_hello/main.cc
@@ -22,10 +22,16 @@ class SampleApp final : public Application {
   }
 
   void draw(CommandEncoder const& cmd) final {
+    auto const clear_color = lina::lerp(
+      vec4{0.26f, 0.20f, 0.24f, 1.0f},
+      vec4{0.9f, 0.75f, 0.5f, 1.0f},
+      cosf(0.75f * elapsed_time()) * 0.5f + 0.5f
+    );
+
 #if 1 /* Direct method */
 
     /* Change the default Render Target clear color value. */
-    renderer_.set_clear_color({0.9f, 0.75f, 0.5f, 1.0f});
+    renderer_.set_clear_color(clear_color);
 
     /**
      * Dynamic rendering directly to the swapchain.
@@ -71,7 +77,7 @@ class SampleApp final : public Application {
           .imageLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL_KHR,
           .loadOp      = VK_ATTACHMENT_LOAD_OP_CLEAR,
           .storeOp     = VK_ATTACHMENT_STORE_OP_STORE,
-          .clearValue  = {{{0.25f, 0.75f, 0.5f, 1.0f}}},
+          .clearValue  = {{ lina::as<VkClearColorValue>(clear_color) }},
         }
       },
       .renderArea = {{0, 0}, renderer_.surface_size()},

--- a/samples/desktop/03_descriptor_set/main.cc
+++ b/samples/desktop/03_descriptor_set/main.cc
@@ -77,17 +77,17 @@ class SampleApp final : public Application {
 
       uniform_buffer_ = cmd.createBufferAndUpload(
         &host_data_, sizeof(host_data_),
-        VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT
+        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
       );
 
       vertex_buffer_ = cmd.createBufferAndUpload(
         kVertices,
-        VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT
+        VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
       );
 
       index_buffer_ = cmd.createBufferAndUpload(
         kIndices,
-        VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT
+        VK_BUFFER_USAGE_INDEX_BUFFER_BIT
       );
 
       context_.finishTransientCommandEncoder(cmd);

--- a/samples/desktop/04_texturing/main.cc
+++ b/samples/desktop/04_texturing/main.cc
@@ -62,17 +62,17 @@ class SampleApp final : public Application {
 
       uniform_buffer_ = cmd.createBufferAndUpload(
         &host_data_, sizeof(host_data_),
-        VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT
+        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
       );
 
       /* Transfer the cube geometry (vertices attributes & indices) to the device. */
       vertex_buffer_ = cmd.createBufferAndUpload(
         cube_.vertices(),
-        VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT
+        VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
       );
       index_buffer_ = cmd.createBufferAndUpload(
         cube_.indices(),
-        VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT
+        VK_BUFFER_USAGE_INDEX_BUFFER_BIT
       );
 
       /* Load a texture using the current transient command encoder. */

--- a/samples/desktop/05_stencil_op/main.cc
+++ b/samples/desktop/05_stencil_op/main.cc
@@ -73,7 +73,7 @@ class SampleApp final : public Application {
 
       uniform_buffer_ = cmd.createBufferAndUpload(
         &host_data_, sizeof(host_data_),
-        VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT
+        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
       );
 
       /* Map to bind vertex attributes with their shader input location. */
@@ -93,11 +93,11 @@ class SampleApp final : public Application {
 
         mesh.vertex = cmd.createBufferAndUpload(
           mesh.vertices(),
-          VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT
+          VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
         );
         mesh.index = cmd.createBufferAndUpload(
           mesh.indices(),
-          VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT
+          VK_BUFFER_USAGE_INDEX_BUFFER_BIT
         );
       }
 
@@ -112,11 +112,11 @@ class SampleApp final : public Application {
 
         mesh.vertex = cmd.createBufferAndUpload(
           mesh.vertices(),
-          VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT
+          VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
         );
         mesh.index = cmd.createBufferAndUpload(
           mesh.indices(),
-          VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT
+          VK_BUFFER_USAGE_INDEX_BUFFER_BIT
         );
       }
 

--- a/samples/desktop/06_blend_op/main.cc
+++ b/samples/desktop/06_blend_op/main.cc
@@ -65,7 +65,7 @@ class SampleApp final : public Application {
 
       uniform_buffer_ = cmd.createBufferAndUpload(
         &host_data_, sizeof(host_data_),
-        VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT
+        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
       );
 
       /* We use storage buffer bit as we will access these attributes procedurally,

--- a/samples/desktop/07_compute/main.cc
+++ b/samples/desktop/07_compute/main.cc
@@ -72,7 +72,7 @@ class SampleApp final : public Application {
 
       uniform_buffer_ = cmd.createBufferAndUpload(
         &host_data_, sizeof(host_data_),
-        VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT
+        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
       );
 
       /* We need to double the size of the device buffers as we

--- a/samples/desktop/08_hdr_envmap/main.cc
+++ b/samples/desktop/08_hdr_envmap/main.cc
@@ -59,13 +59,13 @@ class SampleApp final : public Application {
         /* Using an internal transient command buffer. */
         uniform_buffer_ = context_.transientCreateBuffer(
           &host_data_, sizeof(host_data_),
-          VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT
+          VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
         );
       } else {
         /* Or writing the data from the host via mapping operations. */
         uniform_buffer_ = context_.createBuffer(
           sizeof(host_data_),
-          VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT,
+          VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
           VMA_MEMORY_USAGE_CPU_TO_GPU
         );
         context_.writeBuffer(uniform_buffer_, &host_data_, sizeof(host_data_));

--- a/samples/desktop/09_post_process/main.cc
+++ b/samples/desktop/09_post_process/main.cc
@@ -34,7 +34,7 @@ class SceneFx final : public RenderTargetFx {
 
     uniform_buffer_ = context_ptr_->createBuffer(
       sizeof(host_data_),
-        VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT
+        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
       | VK_BUFFER_USAGE_TRANSFER_DST_BIT
     );
 

--- a/samples/desktop/11_raytracing/main.cc
+++ b/samples/desktop/11_raytracing/main.cc
@@ -227,6 +227,13 @@ class BasicRayTracingFx : public RayTracingFx {
 class SampleApp final : public Application {
  private:
   bool setup() final {
+
+    auto const& features = context_.get_features();
+    if (!features.ray_tracing_pipeline.rayTracingPipeline) {
+      LOGW("This device does not support ray tracing pipeline.");
+      return false;
+    }
+
     wm_->set_title("11 - shining through");
 
     renderer_.set_clear_color({ 0.16f, 0.14f, 0.12f, 1.0f });

--- a/samples/desktop/12_font/main.cc
+++ b/samples/desktop/12_font/main.cc
@@ -57,7 +57,7 @@ class SampleApp final : public Application {
     {
       uniform_buffer_ = context_.createBuffer(
         sizeof(host_data_),
-        VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT,
+        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
         VMA_MEMORY_USAGE_CPU_TO_GPU
       );
     }
@@ -170,13 +170,13 @@ class SampleApp final : public Application {
 
       vertex_buffer_ = context_.transientCreateBuffer(
         mesh.vertices(),
-        VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT
+        VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
       );
 
       if (mesh.index_count() > 0) {
         index_buffer_ = context_.transientCreateBuffer(
           mesh.indices(),
-          VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT
+          VK_BUFFER_USAGE_INDEX_BUFFER_BIT
         );
       }
     } else {

--- a/third_party/lina/lina.h
+++ b/third_party/lina/lina.h
@@ -1,4 +1,4 @@
-//  lina.h - v0.9.0
+//  lina.h - v0.10.0
 //
 //  Public domain linear algebra header, wrapping sgorsten/linalg.h
 //  <http://unlicense.org/>
@@ -131,14 +131,15 @@ template<class T, int M, int N> constexpr T* ptr(mat<T, M, N> & m) { return &m.x
 template<class T, int M> constexpr T const* ptr(vec<T, M> const& v) { return &v.x; }
 template<class T, int M, int N> constexpr T const* ptr(mat<T, M, N> const& m) { return &m.x.x; }
 
+template<class D, class T, int M> constexpr D as(vec<T, M> const& v) { return *reinterpret_cast<const D*>(ptr(v)); }
+
 template<class T> constexpr vec<T, 2> to_vec2(vec<T, 3> const& v) { return {v.x,v.y}; }
 template<class T> constexpr vec<T, 3> to_vec3(vec<T, 4> const& v) { return {v.x,v.y,v.z}; }
+template<class T> constexpr mat<T, 3, 3> to_mat3(mat<T, 4, 4> const& v) { return {to_vec3(v.x),to_vec3(v.y),to_vec3(v.z)}; }
+template<class T> constexpr mat<T, 3, 4> to_mat3x4(mat<T, 4, 4> const& v) { return {to_vec3(v.x),to_vec3(v.y),to_vec3(v.z), to_vec3(v.w)}; }
 
 template<class T> constexpr vec<T, 3> to_vec3(vec<T, 2> const& v, T z = 0) { return {v.x,v.y,z}; }
 template<class T> constexpr vec<T, 4> to_vec4(vec<T, 3> const& v, T w = 0) { return {v.x,v.y,v.z,w}; }
-
-template<class T> constexpr mat<T, 3, 3> to_mat3(mat<T, 4, 4> const& v) { return {to_vec3(v.x),to_vec3(v.y),to_vec3(v.z)}; }
-template<class T> constexpr mat<T, 3, 4> to_mat3x4(mat<T, 4, 4> const& v) { return {to_vec3(v.x),to_vec3(v.y),to_vec3(v.z), to_vec3(v.w)}; }
 template<class T> constexpr mat<T, 4, 4> to_mat4(mat<T, 3, 3> const& v) { return {to_vec4(v.x),to_vec4(v.y),to_vec4(v.z), {0, 0, 0, 1}}; }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
- Add `createBuffer` variations to debug name the buffer,
- Rename VkBufferUsageFlags2KHR flags across the framework to VkBufferUsageFlags for consistency,
- Rename VulkanContextFeature, variable and method to their plural version,
- Comment unused feature `DescriptorBuffer`,
- Remove Skybox pushConstant multiview matrices to keep only one,
- Add clear color animation to sample_00